### PR TITLE
Fix removal list arg usage

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -540,7 +540,7 @@ if args.access_method=="api":
     if args.f_remlist:
         exists = os.path.isfile(args.f_remlist)
         if exists:
-            with open(args.remlist) as f:
+            with open(args.f_remlist) as f:
                 for line in f:
                     success = api.remove_cred(creds, line.strip())
                     if success:


### PR DESCRIPTION
## Summary
- use `args.f_remlist` when loading credential removal lists

## Testing
- `python3 -m py_compile dismal.py`

------
https://chatgpt.com/codex/tasks/task_e_686bc524bec883268b04dcb6e318c26c