### PR TITLE
Fix scan range list check

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -738,7 +738,7 @@ def get_scans(results, list_of_ranges):
         msg = "Result: %s" % result
         logger.debug(msg)
         ranges = result.get('Scan_Range')
-        if ranges and ranges is list:
+        if ranges and isinstance(ranges, list):
             for scan_range in ranges:
                 msg = "Scan Range: %s" % scan_range
                 logger.debug(msg)


### PR DESCRIPTION
## Summary
- fix type check when iterating scan ranges

## Testing
- `python -m py_compile core/builder.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bc65ba1948326b3aaae27df333aa5