### PR TITLE
Fix CSV parsing when saving CLI data

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -73,7 +73,7 @@ def save2csv(clidata, filename, appliance):
                 try:
                     columns = [c.strip() for c in line.split(',')]
                     columns.insert(0, appliance)
-                    data.append( tools.dequote(columns) )
+                    data.append([tools.dequote(c) for c in columns])
                 except Exception as e:
                     logger.error("Problem writing line to CSV:\n%s\n%s\n%s"%(line,e.__class__,str(e)))
                     # Try dumping it instead


### PR DESCRIPTION
## Summary
- fix `save2csv` to dequote each field

## Testing
- `python -m compileall -q core/output.py core/tools.py dismal.py`
- `pytest -q` *(no tests found)*
- `python dismal.py -h`

------
https://chatgpt.com/codex/tasks/task_e_686bc6dea72083268e41933a4c0f293b