### PR TITLE
Fix stray attribute check causing CLI failure

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -656,9 +656,6 @@ if args.access_method=="api":
     
     if args.excavate and args.excavate[0] == "hostname":
         api.hostname(args, reporting_dir)
-    
-    if args.r_schedules:
-        api.schedules(search, reporting_dir, args.target)
 
 if cli_target:
     cli_target.close()


### PR DESCRIPTION
## Summary
- clean up a leftover argument check
- ensure tests run

## Testing
- `pip install -q cidrize`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f93a31c5083268513b5917ab4839c