### PR TITLE
Handle password prompting based on username

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -58,36 +58,45 @@ def remote_cmd(cmd, client):
         output = error
     return output
 
-def login_target(client,args):
+def login_target(client, args):
     target = args.target
     system_user = args.username
     syspass = args.password
-    
+
+    # If no credentials are provided at all, don't prompt
+    if not system_user and not syspass and not args.f_passwd:
+        return None, None
+
     if not syspass:
         if args.f_passwd:
             exists = os.path.isfile(args.f_passwd)
             if exists:
-                f=open(args.f_passwd, 'r')
-                passwd=f.read()
+                f = open(args.f_passwd, 'r')
+                syspass = f.read()
                 f.close()
             else:
                 msg = "Login password file not found!\n"
                 print(msg)
                 logger.error(msg)
-        else:
-            syspass = getpass.getpass(prompt='Please enter your system administrator password (enter=skip): ')
-    
-    if not syspass:
+        elif system_user:
+            syspass = getpass.getpass(
+                prompt='Please enter your system administrator password (enter=skip): '
+            )
+
+    if system_user and not syspass:
         msg = "No system user password supplied."
         print(msg)
         logger.warning(msg)
-    
-    if client and syspass:
-        msg = "\nChecking %s login for %s..." %(system_user,target)
+
+    if client and system_user and syspass:
+        msg = "\nChecking %s login for %s..." % (system_user, target)
         print(msg)
         logger.info(msg)
         try:
-            result = remote_cmd("tw_options -u %s -p %s > /dev/null && echo $?"%(system_user,syspass), client)
+            result = remote_cmd(
+                "tw_options -u %s -p %s > /dev/null && echo $?" % (system_user, syspass),
+                client,
+            )
             if result == "ERROR: Authentication unsuccessful":
                 print(result)
                 logger.error(msg)
@@ -97,7 +106,7 @@ def login_target(client,args):
                 logger.info(result)
                 logger.info(msg)
         except Exception as e:
-            msg = "Problem logging into %s\n%s" % (target,e)
+            msg = "Problem logging into %s\n%s" % (target, e)
             print(msg)
             logger.error(msg)
     else:


### PR DESCRIPTION
## Summary
- only prompt for password when username given
- skip password prompt entirely when no credentials are supplied
- check for username before verifying authentication

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa6975a64832697e5f97c31e318b9