### PR TITLE
Fix OS string comparison

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -23,7 +23,7 @@ def ping(target):
     if current_os == "windows":
         parameters = "-n 1 -w 2"
         null = "$null"
-    elif current_os == "Linux":
+    elif current_os == "linux":
         parameters = "-c 1 -w2"
         null = "/dev/null"
     else: # Mac


### PR DESCRIPTION
## Summary
- fix Linux OS comparison in `core/access.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa7c84d4083269c0f45d764224fe0