### PR TITLE
Fix warning call in login_target

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -103,7 +103,7 @@ def login_target(client,args):
     else:
         msg = "System user auth not checked."
         print(msg)
-        logger.warn(msg)
+        logger.warning(msg)
 
     return system_user, syspass
 


### PR DESCRIPTION
## Summary
- use `logger.warning` instead of deprecated `logger.warn` in `login_target`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa8a58808832699c7a6c2c60bcb8b