### PR TITLE
Fix UnboundLocalError in device report

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -249,6 +249,8 @@ def devices(twsearch, twcreds, args):
     results = api.search_results(twsearch,queries.deviceInfo)
 
     devices = []
+    msg = None
+    headers = []
 
     # Build the results
 
@@ -531,7 +533,8 @@ def devices(twsearch, twcreds, args):
                     "last_access_method"
                     ]
 
-    print(msg)
+    if msg:
+        print(msg)
     output.report(data, headers, args)
 
 def ipaddr(search, credentials, args):


### PR DESCRIPTION
## Summary
- initialize message and header variables in `devices`
- guard message print if undefined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb51516c0832686fb6689ed018a23