### PR TITLE
Improve API query and credential ordering

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -134,12 +134,13 @@ def licensing(disco, args, dir):
             if chunk:  # filter out keep-alive new chunks
                 handle.write(chunk)
 
-def query(disco, args):
+def query(search, args):
+    """Run an ad-hoc query against the search endpoint."""
     results = []
     try:
-        results = disco.search_bulk(args.a_query,limit=500)
+        results = search.search_bulk(args.a_query, limit=500)
     except Exception as e:
-        msg = "Not able to make api call.\nQuery: %s\nException: %s" %(args.a_query,e.__class__)
+        msg = "Not able to make api call.\nQuery: %s\nException: %s" % (args.a_query, e.__class__)
         print(msg)
         logger.error(msg)
     if len(results) > 0:

--- a/core/builder.py
+++ b/core/builder.py
@@ -144,6 +144,12 @@ def ordering(creds, search, args, apply):
     print(msg)
     logger.info(msg)
 
+    if not credlist:
+        msg = "Credential list could not be retrieved."
+        print(msg)
+        logger.error(msg)
+        return
+
     cred_weighting = []
     
     for cred in credlist:


### PR DESCRIPTION
## Summary
- fix `api.query` to call search endpoint
- guard against missing credential list in `builder.ordering`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb93f53f083269a74627aa9ea6901