### PR TITLE
Improve API call error handling

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core.api import get_json, search_results
+
+class DummyResponse:
+    def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
+        self.status_code = status_code
+        self._data = data
+        self.reason = reason
+        self.url = url
+        self.ok = status_code == 200
+    def json(self):
+        import json
+        return json.loads(self._data)
+
+class DummySearch:
+    def __init__(self, response):
+        self._response = response
+    def search(self, query, format="object", limit=500):
+        return self._response
+
+def test_get_json_success():
+    resp = DummyResponse(200, '{"a":1}')
+    assert get_json(resp) == {"a":1}
+
+def test_get_json_bad_json():
+    resp = DummyResponse(200, 'not-json')
+    assert get_json(resp) == {}
+
+def test_search_results_fallback():
+    resp = DummyResponse(200, '[{"ok": true}]')
+    search = DummySearch(resp)
+    assert search_results(search, {"query": "q"}) == [{"ok": True}]


### PR DESCRIPTION
## Summary
- fix logger escape sequence
- improve `get_json` to handle connection and JSON errors gracefully
- allow fallbacks for `search_bulk` calls
- add tests for new API helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc067ced08326a20100e2f4b9f792