### PR TITLE
Improve API error handling

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -43,8 +43,19 @@ def successful(creds, search, args):
     failCreds = tools.session_get(credfail_results)
 
     # Include Scan Ranges and Excludes
-    scan_ranges = api.get_json(search.search(queries.scanrange,format="object",limit=500))
-    excludes = api.get_json(search.search(queries.excludes,format="object",limit=500))
+    scan_resp = search.search(queries.scanrange,format="object",limit=500)
+    scan_ranges = api.get_json(scan_resp)
+    excludes_resp = search.search(queries.excludes,format="object",limit=500)
+    excludes = api.get_json(excludes_resp)
+    if not scan_ranges or not isinstance(scan_ranges, list):
+        logger.error("Failed to retrieve scan ranges")
+        return
+    if not excludes or not isinstance(excludes, list):
+        logger.error("Failed to retrieve excludes")
+        return
+    if len(scan_ranges) == 0 or len(excludes) == 0:
+        logger.error("No scan or exclude data returned")
+        return
 
     timer_count = 0
     for cred in vaultcreds:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.builder as builder
+
+
+class DummyResponse:
+    status_code = 401
+    ok = False
+    reason = "Unauthorized"
+    url = "http://x"
+
+    def json(self):
+        return {}
+
+
+class DummySearch:
+    def search(self, query, format="object", limit=500):
+        return DummyResponse()
+
+
+def test_overlapping_handles_bad_api(monkeypatch):
+    called = {}
+
+    def fake_report(data, headers, args):
+        called["ran"] = True
+
+    monkeypatch.setattr(builder, "output", types.SimpleNamespace(report=fake_report))
+    args = types.SimpleNamespace(output_csv=False, output_file=None)
+
+    # Should not raise even though API call fails
+    builder.overlapping(DummySearch(), args)
+
+    # If the function returned early, fake_report won't be called
+    assert "ran" not in called
+


### PR DESCRIPTION
## Summary
- avoid crashing when API calls fail in overlapping report
- validate device lookup results before accessing
- ensure success report checks search results
- add regression test for overlapping() handling bad API responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc86620488326a796252b095fe93b