### PR TITLE
Fix unbound headers when API fails

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -710,6 +710,7 @@ def discovery_access(twsearch, twcreds, args):
 
     disco_data = []
     unique_endpoints = []
+    headers = []
 
     # Get a list of Unique IPs
     for result in discos:
@@ -1047,6 +1048,7 @@ def discovery_analysis(twsearch, twcreds, args):
 
     disco_data = []
     unique_endpoints = []
+    headers = []
 
     # Get a list of Unique IPs
     for result in discos:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.reporting as reporting
+
+class DummyResponse:
+    status_code = 401
+    ok = False
+    reason = "Unauthorized"
+    url = "http://x"
+    def json(self):
+        return {}
+
+class DummySearch:
+    def search(self, query, format="object", limit=500):
+        return DummyResponse()
+
+class DummyCreds:
+    def get_vault_credentials(self):
+        return DummyResponse()
+
+
+def _run_with_patches(monkeypatch, func):
+    monkeypatch.setattr(reporting.builder, "unique_identities", lambda s: [])
+    monkeypatch.setattr(reporting.api, "search_results", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+    called = {}
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda d, h, a: called.setdefault("ran", True)))
+    args = types.SimpleNamespace(output_csv=False, output_file=None)
+    func(DummySearch(), DummyCreds(), args)
+    assert "ran" in called
+
+
+def test_discovery_access_handles_bad_api(monkeypatch):
+    _run_with_patches(monkeypatch, reporting.discovery_access)
+
+
+def test_discovery_analysis_handles_bad_api(monkeypatch):
+    _run_with_patches(monkeypatch, reporting.discovery_analysis)


### PR DESCRIPTION
## Summary
- avoid `UnboundLocalError` when API calls fail in `discovery_access` and `discovery_analysis`
- add regression tests for these cases

## Testing
- `pip install cidrize`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fce2d89d083269c9ccda5b5ae1b7a