### PR TITLE
Improve API error handling and debug output

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -13,10 +13,24 @@ import paramiko
 logger = logging.getLogger("_access_")
 
 def api_version(tw):
-    about = tw.about()
-    if about.ok:
-        version = about.json()['api_versions'][-1]
-        return(about, version)
+    """Return (about, version) tuple or (None, None) on failure."""
+    try:
+        about = tw.about()
+    except Exception as e:  # pragma: no cover - network errors
+        logger.error("Problem retrieving API version: %s", e)
+        return None, None
+
+    if not about.ok:
+        logger.error("About call failed: %s - %s", about.status_code, about.reason)
+        return None, None
+
+    try:
+        version = about.json().get("api_versions", [])[-1]
+    except Exception as e:
+        logger.error("Error parsing about information: %s", e)
+        version = None
+
+    return about, version
 
 def ping(target):
     current_os = platform.system().lower()
@@ -183,14 +197,15 @@ def api_target(args):
 
         try:
             about, apiver = api_version(disco)
-            msg = "About: %s\n"%about.json()
-            logger.info(msg)
+            if about is not None:
+                msg = "About: %s\n" % about.json()
+                logger.info(msg)
             if apiver:
-                disco = tideway.appliance(target,token,api_version=apiver)
+                disco = tideway.appliance(target, token, api_version=apiver)
             else:
-                disco = tideway.appliance(target,token)
+                disco = tideway.appliance(target, token)
             msg = "API found on %s." % target
-            logger.info(msg)            
+            logger.info(msg)
         except OSError as e:
             msg = "Error connecting to %s\n%s\n" % (target,e)
             print(msg)

--- a/core/api.py
+++ b/core/api.py
@@ -102,13 +102,26 @@ def get_json(api_endpoint):
             print(msg)
             logger.error(msg)
 
+    if logger.isEnabledFor(logging.DEBUG):
+        try:
+            logger.debug("API response text from %s:\n%s" % (url, api_endpoint.text))
+        except Exception:
+            pass
+
     try:
-        return api_endpoint.json()
+        data = api_endpoint.json()
     except Exception as e:  # pragma: no cover - unexpected JSON issues
         msg = "Error decoding JSON from %s: %s" % (url, str(e))
         print(msg)
         logger.error(msg)
         return {}
+    else:
+        if logger.isEnabledFor(logging.DEBUG):
+            try:
+                logger.debug("Decoded JSON from %s:\n%s" % (url, json.dumps(data, indent=2)))
+            except Exception:
+                pass
+        return data
 
 def admin(disco,args,dir):
     data = disco.admin()
@@ -230,47 +243,43 @@ def discovery_runs(disco, args, dir):
         output.define_csv(args,None,rows,dir+defaults.current_scans_filename,args.output_file,args.target,"csv_file")
 
 def show_runs(disco, args):
-    results = []
-    try:
-        results = disco.get_discovery_runs
-    except Exception as e:
-        msg = "Not able to make api call.\nException: %s" %(e.__class__)
-        print(msg)
-        logger.error(msg)
-    if len(results.json()) > 0:
-        runs = []
-        headers =[]
-        for run in results.json():
-            disco_run = {}
-            for key in run:
-                disco_run.update({key:run[key]})
-                headers.append(key)
-            runs.append(disco_run)
-        headers = tools.sortlist(headers)
-        run_csvs = []
-        for run in runs:
-            run_csv = []
-            for header in headers:
-                value = run.get(header)
-                run_csv.append(value)
-            run_csvs.append(run_csv)
-        run_csvs.insert(0, headers)
-        if args.export:
-            w = csv.writer(sys.stdout)
-            w.writerows(run_csvs)
-        elif args.file:
-            with open(args.file, 'w', newline='') as file:
-                writer = csv.writer(file)
-                writer.writerows(run_csvs)
-                msg = "Results written to %s" % args.file
-                print(msg)
-                logger.info(msg)
-        else:
-            pprint(results.json())
-    else:
+    runs = get_json(disco.get_discovery_runs)
+    if not runs:
         msg = "No runs in progress."
         print(msg)
         logger.error(msg)
+        return
+
+    processed = []
+    headers = []
+    for run in runs:
+        disco_run = {}
+        for key in run:
+            disco_run.update({key: run[key]})
+            headers.append(key)
+        processed.append(disco_run)
+
+    headers = tools.sortlist(headers)
+    run_csvs = []
+    for run in processed:
+        run_csv = []
+        for header in headers:
+            run_csv.append(run.get(header))
+        run_csvs.append(run_csv)
+
+    run_csvs.insert(0, headers)
+    if args.export:
+        w = csv.writer(sys.stdout)
+        w.writerows(run_csvs)
+    elif args.file:
+        with open(args.file, "w", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerows(run_csvs)
+            msg = "Results written to %s" % args.file
+            print(msg)
+            logger.info(msg)
+    else:
+        pprint(runs)
 
 def sensitive(search, args, dir):
     output.define_csv(args,search,queries.sensitive_data,dir+defaults.sensitive_data_filename,args.output_file,args.target,"query")

--- a/dismal.py
+++ b/dismal.py
@@ -50,7 +50,8 @@ outputs.add_argument('--null',          dest='output_null',  action='store_true'
 
 # Hidden Options
 parser.add_argument('-k', '--keep-awake',   dest='wakey', action='store_true', required=False, help=argparse.SUPPRESS)
-parser.add_argument('--debug',              dest='debugging',  action='store_true', required=False, help=argparse.SUPPRESS)
+parser.add_argument('--debug',              dest='debugging',  action='store_true', required=False,
+                    help='Enable debug logging including full API responses.\n\n')
 
 # CLI Appliance Management
 cli_management = parser.add_argument_group("CLI Appliance Management")
@@ -183,9 +184,10 @@ if args.target:
     if not os.path.exists(reporting_dir):
         os.makedirs(reporting_dir)
 
-logging.basicConfig(level=logging.INFO, filename=logfile, filemode='w',force=True)
+logging.basicConfig(level=logging.INFO, filename=logfile, filemode='w', force=True)
 logger = logging.getLogger("_dismal_")
 if args.debugging:
+    logging.getLogger().setLevel(logging.DEBUG)
     logger.setLevel(logging.DEBUG)
 
 logger.info("DisMAL Version %s"%vers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k
 sys.modules.setdefault("tideway", types.SimpleNamespace())
 sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from core.api import get_json, search_results
+from core.api import get_json, search_results, show_runs
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -26,6 +26,13 @@ class DummySearch:
     def search(self, query, format="object", limit=500):
         return self._response
 
+class DummyDisco:
+    def __init__(self, response):
+        self._response = response
+    @property
+    def get_discovery_runs(self):
+        return self._response
+
 def test_get_json_success():
     resp = DummyResponse(200, '{"a":1}')
     assert get_json(resp) == {"a":1}
@@ -38,3 +45,15 @@ def test_search_results_fallback():
     resp = DummyResponse(200, '[{"ok": true}]')
     search = DummySearch(resp)
     assert search_results(search, {"query": "q"}) == [{"ok": True}]
+
+
+def test_show_runs_handles_bad_response(capsys):
+    resp = DummyResponse(401, reason="Unauthorized")
+    disco = DummyDisco(resp)
+    args = types.SimpleNamespace(export=False, file=None)
+
+    # Should not raise even though the response is 401/invalid
+    show_runs(disco, args)
+
+    out, _ = capsys.readouterr()
+    assert "No runs in progress" in out


### PR DESCRIPTION
## Summary
- log raw API responses at debug level
- handle errors gracefully in `show_runs`
- make `api_version` return safe defaults
- honour `--debug` flag by raising root logger level
- test `show_runs` behaviour on bad API responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd05f210c8326ab1e5716f5da64f6