### PR TITLE
Improve handling of failed about call

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -16,7 +16,12 @@ def api_version(tw):
     about = tw.about()
     if about.ok:
         version = about.json()['api_versions'][-1]
-        return(about, version)
+        return about, version
+    logger.error(
+        "Failed to get about information: %s",
+        getattr(about, "reason", "unknown"),
+    )
+    return None, None
 
 def ping(target):
     current_os = platform.system().lower()
@@ -183,14 +188,15 @@ def api_target(args):
 
         try:
             about, apiver = api_version(disco)
-            msg = "About: %s\n"%about.json()
-            logger.info(msg)
-            if apiver:
-                disco = tideway.appliance(target,token,api_version=apiver)
-            else:
-                disco = tideway.appliance(target,token)
-            msg = "API found on %s." % target
-            logger.info(msg)            
+            if about is not None:
+                msg = "About: %s\n" % about.json()
+                logger.info(msg)
+                if apiver:
+                    disco = tideway.appliance(target, token, api_version=apiver)
+                else:
+                    disco = tideway.appliance(target, token)
+                msg = "API found on %s." % target
+                logger.info(msg)
         except OSError as e:
             msg = "Error connecting to %s\n%s\n" % (target,e)
             print(msg)

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.access as access
+
+class DummyResponse:
+    def __init__(self, ok=True, reason="OK"):
+        self.ok = ok
+        self.reason = reason
+    def json(self):
+        return {"api_versions": ["v1"]}
+
+class DummyTW:
+    def __init__(self, resp):
+        self._resp = resp
+    def about(self):
+        return self._resp
+
+def test_api_version_returns_none_on_failure(caplog):
+    tw = DummyTW(DummyResponse(ok=False, reason="fail"))
+    about, version = access.api_version(tw)
+    assert about is None
+    assert version is None
+    assert "fail" in caplog.text
+
+
+def test_api_target_handles_missing_about(monkeypatch):
+    class DummySwagger:
+        ok = True
+        url = "http://x"
+    class DummyAppliance:
+        def swagger(self):
+            return DummySwagger()
+    dummy_app = DummyAppliance()
+    args = types.SimpleNamespace(target="t", token="tok", f_token=None)
+    monkeypatch.setattr(access, "api_version", lambda x: (None, None))
+    monkeypatch.setattr(access.tideway, "appliance", lambda *a, **k: dummy_app, raising=False)
+    result = access.api_target(args)
+    assert result is dummy_app


### PR DESCRIPTION
## Summary
- avoid unpack errors when `about` fails
- check `about` before calling `.json()`
- test access helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd4993c1c8326b6a975c854948384