### PR TITLE
Handle invalid response in show_runs

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -237,10 +237,12 @@ def show_runs(disco, args):
         msg = "Not able to make api call.\nException: %s" %(e.__class__)
         print(msg)
         logger.error(msg)
-    if len(results.json()) > 0:
+
+    runs_json = get_json(results)
+    if runs_json:
         runs = []
-        headers =[]
-        for run in results.json():
+        headers = []
+        for run in runs_json:
             disco_run = {}
             for key in run:
                 disco_run.update({key:run[key]})
@@ -266,7 +268,7 @@ def show_runs(disco, args):
                 print(msg)
                 logger.info(msg)
         else:
-            pprint(results.json())
+            pprint(runs_json)
     else:
         msg = "No runs in progress."
         print(msg)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k
 sys.modules.setdefault("tideway", types.SimpleNamespace())
 sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from core.api import get_json, search_results
+from core.api import get_json, search_results, show_runs
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -26,6 +26,10 @@ class DummySearch:
     def search(self, query, format="object", limit=500):
         return self._response
 
+class DummyDisco:
+    def __init__(self, response):
+        self.get_discovery_runs = response
+
 def test_get_json_success():
     resp = DummyResponse(200, '{"a":1}')
     assert get_json(resp) == {"a":1}
@@ -38,3 +42,14 @@ def test_search_results_fallback():
     resp = DummyResponse(200, '[{"ok": true}]')
     search = DummySearch(resp)
     assert search_results(search, {"query": "q"}) == [{"ok": True}]
+
+
+def test_show_runs_handles_bad_response(capsys):
+    resp = DummyResponse(401, 'not-json', reason="Unauthorized")
+    disco = DummyDisco(resp)
+    args = types.SimpleNamespace(export=False, file=None)
+
+    show_runs(disco, args)
+
+    captured = capsys.readouterr()
+    assert "No runs in progress." in captured.out


### PR DESCRIPTION
## Summary
- guard `show_runs` against bad API responses
- unit test for `show_runs` with invalid JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd496c4cc8326a930b8b481d7c255