### PR TITLE
Improve endpoint logging

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -21,7 +21,11 @@ def api_version(tw):
         return None, None
 
     if not about.ok:
-        logger.error("About call failed: %s - %s", about.status_code, about.reason)
+        logger.error(
+            "About call failed: %s - %s",
+            getattr(about, "status_code", "unknown"),
+            getattr(about, "reason", "unknown"),
+        )
         return None, None
 
     try:

--- a/core/api.py
+++ b/core/api.py
@@ -17,35 +17,45 @@ logger = logging.getLogger("_api_")
 
 def init_endpoints(api_target, args):
     try:
+        logger.debug("Requesting discovery endpoint from %s", args.target)
         disco = api_target.discovery()
+        logger.debug("Discovery endpoint obtained: %s", disco)
     except:
         msg = "Error getting Discovery endpoint from %s\n" % (args.target)
         print(msg)
         logger.error(msg)
         sys.exit(1)
     try:
+        logger.debug("Requesting data endpoint from %s", args.target)
         search = api_target.data()
+        logger.debug("Data endpoint obtained: %s", search)
     except:
         msg = "Error getting Data endpoint from %s\n" % (args.target)
         print(msg)
         logger.error(msg)
         sys.exit(1)
     try:
+        logger.debug("Requesting credentials endpoint from %s", args.target)
         creds = api_target.credentials()
+        logger.debug("Credentials endpoint obtained: %s", creds)
     except:
         msg = "Error getting Credentials endpoint from %s\n" % (args.target)
         print(msg)
         logger.error(msg)
         sys.exit(1)
     try:
+        logger.debug("Requesting vault endpoint from %s", args.target)
         vault = api_target.vault()
+        logger.debug("Vault endpoint obtained: %s", vault)
     except:
         msg = "Error getting Vault endpoint from %s\n" % (args.target)
         print(msg)
         logger.error(msg)
         sys.exit(1)
     try:
+        logger.debug("Requesting knowledge endpoint from %s", args.target)
         knowledge = api_target.knowledge()
+        logger.debug("Knowledge endpoint obtained: %s", knowledge)
     except:
         msg = "Error getting Knowledge endpoint from %s\n" % (args.target)
         print(msg)


### PR DESCRIPTION
## Summary
- add debug logs around API endpoint creation in `init_endpoints`
- avoid attribute errors in `api_version` when `status_code` or `reason` are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fda643dc8832694bca374713ac0b6