### PR TITLE
Improve token argument validation

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -177,6 +177,16 @@ def api_target(args):
     disco = None
     use_api = False
 
+    # If a file path is accidentally provided via -t/--token, warn the user
+    if token and os.path.isfile(token):
+        msg = (
+            "Token argument appears to be a file. "
+            "Use -T/--token_file to specify a token file."
+        )
+        print(msg)
+        logger.error(msg)
+        sys.exit(1)
+
     if args.f_token:
         exists = os.path.isfile(args.f_token)
         if exists:
@@ -184,7 +194,9 @@ def api_target(args):
             token=f.read().strip()
             f.close()
         else:
-            msg = "Token file not found!\n"
+            msg = "Token file not found!"
+            if args.f_token and not os.path.isfile(args.f_token):
+                msg += " Did you mean to use -t/--token?"
             print(msg)
             logger.error(msg)
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -9,6 +9,7 @@ sys.modules.setdefault("paramiko", types.SimpleNamespace())
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import pytest
 import core.access as access
 
 class DummyResponse:
@@ -45,3 +46,15 @@ def test_api_target_handles_missing_about(monkeypatch):
     monkeypatch.setattr(access.tideway, "appliance", lambda *a, **k: dummy_app, raising=False)
     result = access.api_target(args)
     assert result is dummy_app
+
+
+def test_api_target_token_is_file(tmp_path, capsys):
+    file_path = tmp_path / "token.txt"
+    file_path.write_text("abc")
+    args = types.SimpleNamespace(target="t", token=str(file_path), f_token=None)
+
+    with pytest.raises(SystemExit):
+        access.api_target(args)
+
+    captured = capsys.readouterr()
+    assert "token_file" in captured.out


### PR DESCRIPTION
## Summary
- catch cases where a token file path is provided to `-t/--token`
- hint at using `--token` when `--token_file` is not a file
- test new token validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a180605c8326823b6332c6edff04