### PR TITLE
Default output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ python3 dismal.py --access_method cli \
 
 The options `-P`, `-T` and `-W` can be used to read the UI password, API token
 and tideway password from files instead of providing them inline.
+
+By default, reports are written to an `output_<appliance>` directory in the
+current working directory. Use the `--stdout` option to suppress file output and
+print results directly to the terminal.

--- a/core/output.py
+++ b/core/output.py
@@ -151,9 +151,8 @@ def query2csv(search, query, filename, appliance):
 
 def define_txt(args,result,path,filename):
     # Manage all Output options
-    if args.access_method == "all":
-        txt_dump(result,path)
-    elif args.output_file:
+    cli_out = getattr(args, "output_cli", False)
+    if args.output_file:
         if filename:
             output_file = filename+"_"+args.output_file
         else:
@@ -167,36 +166,40 @@ def define_txt(args,result,path,filename):
     elif args.output_null:
         print("Report completed (null).")
     else:
-        print(result)
+        if cli_out:
+            print(result)
+        else:
+            txt_dump(result,path)
 
 def define_csv(args,head_ep,data,path,file,target,type):
     # Manage all Output options
+    cli_out = getattr(args, "output_cli", False)
     if type == "cmd":
-        if args.access_method == "all":
-            cmd2csv(head_ep, data, ":", path, target)
-        elif args.output_file:
+        if args.output_file:
             cmd2csv(head_ep, data, ":", file, target)
         elif args.output_csv:
             cmd2csv_out(head_ep, data, ":")
         elif args.output_null:
             print("Report completed (null).")
         else:
-            print(data)
+            if cli_out:
+                print(data)
+            else:
+                cmd2csv(head_ep, data, ":", path, target)
     elif type == "csv":
-        if args.access_method == "all":
-            save2csv(data, path, target)
-        elif args.output_file:
+        if args.output_file:
             save2csv(data, file, target)
         elif args.output_csv:
             print(data)
         elif args.output_null:
             print("Report completed (null).")
         else:
-            print(data)
+            if cli_out:
+                print(data)
+            else:
+                save2csv(data, path, target)
     elif type == "query":
-        if args.access_method == "all":
-            query2csv(head_ep, data, path, target)
-        elif args.output_file:
+        if args.output_file:
             query2csv(head_ep, data, file, target)
         elif args.output_csv:
             msg ="DisMAL: Output cannot be export to CLI."
@@ -205,13 +208,14 @@ def define_csv(args,head_ep,data,path,file,target,type):
         elif args.output_null:
             print("Report function completed (null).")
         else:
-            msg ="DisMAL: Output cannot be export to CLI."
-            logger.warning(msg)
-            print(msg)
+            if cli_out:
+                msg ="DisMAL: Output cannot be export to CLI."
+                logger.warning(msg)
+                print(msg)
+            else:
+                query2csv(head_ep, data, path, target)
     elif type == "csv_file":
-        if args.access_method == "all":
-            csv_file(data, head_ep, path)
-        elif args.output_file:
+        if args.output_file:
             csv_file(data, head_ep, file)
         elif args.output_csv:
             msg ="DisMAL: Output cannot be export to CLI."
@@ -220,6 +224,9 @@ def define_csv(args,head_ep,data,path,file,target,type):
         elif args.output_null:
             print("Report function completed (null).")
         else:
-            msg ="DisMAL: Output cannot be export to CLI."
-            logger.warning(msg)
-            print(msg)
+            if cli_out:
+                msg ="DisMAL: Output cannot be export to CLI."
+                logger.warning(msg)
+                print(msg)
+            else:
+                csv_file(data, head_ep, path)

--- a/dismal.py
+++ b/dismal.py
@@ -47,6 +47,7 @@ outputs.add_argument('-c', '--csv',     dest='output_csv', action='store_true', 
 outputs.add_argument('-f', '--file',    dest='output_file', type=str, required=False, help='Output file (TXT/CSV format).\n\n',metavar='<filename>')
 outputs.add_argument('-s', '--path',    dest='output_path', type=str, required=False, help='Path to save bulk files (default=pwd).\n\n',metavar='<path>')
 outputs.add_argument('--null',          dest='output_null',  action='store_true', required=False, help='Run report functions but do not output data (used for debugging).\n\n')
+outputs.add_argument('--stdout',       dest='output_cli', action='store_true', required=False, help='Print results to CLI instead of writing to output directory.\n\n')
 
 # Hidden Options
 parser.add_argument('-k', '--keep-awake',   dest='wakey', action='store_true', required=False, help=argparse.SUPPRESS)


### PR DESCRIPTION
## Summary
- add `--stdout` flag
- write output to files by default when no option is specified
- update README

## Testing
- `pip install -r requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880a54ea104832690ce24a4362ada0d