### PR TITLE
Ensure excavate reports are saved

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -133,7 +133,7 @@ def get_credential(twsearch, twcreds, args):
                             "Result/Reason",
                             "Successful",
                             "Access Time"
-                        ], args)
+                        ], args, name="devices_with_cred")
 
     return found
 
@@ -297,7 +297,7 @@ def ordering(creds, search, args, apply):
         logger.info(msg)
         data.append([index, label])
 
-    output.report(data, headers, args)
+    output.report(data, headers, args, name="suggested_cred_opt")
 
 def get_device(search, credentials, args):
     dev = args.excavate[1]
@@ -415,7 +415,7 @@ def get_device(search, credentials, args):
                             "Status",
                             "Message",
                             "Successful"
-                            ], args)
+                            ], args, name="device")
 
 def scheduling(vault, search, args):
     ## Schedules compared to runs
@@ -563,7 +563,7 @@ def scheduling(vault, search, args):
     if msg:
         print(msg)
 
-    output.report(data, [ "Name", "Type", "Range ID", "Ranges", "Scan Level", "When", "Credentials" ], args)
+    output.report(data, [ "Name", "Type", "Range ID", "Ranges", "Scan Level", "When", "Credentials" ], args, name="schedules")
 
 def unique_identities(search):
 
@@ -797,7 +797,7 @@ def overlapping(tw_search, args):
         logger.info(msg)
         print(msg)
 
-    output.report(data, [ "IP Address", "Scan Schedules" ], args)
+    output.report(data, [ "IP Address", "Scan Schedules" ], args, name="overlapping_ips")
 
 def get_scans(results, list_of_ranges):
     scan_ranges = []

--- a/core/output.py
+++ b/core/output.py
@@ -3,6 +3,7 @@
 import sys
 import logging
 import csv
+import os
 
 # PIP Modules
 from tabulate import tabulate
@@ -98,9 +99,11 @@ def fancy_out(data, heads):
     except Exception as e:
         logger.error("Problem printing fancy output:%s\n%s"%(e.__class__,str(e)))
 
-def report(data, heads, args):
+def report(data, heads, args, name=None):
     """Handle generic report output."""
     cli_out = getattr(args, "output_cli", False)
+    excavate = getattr(args, "excavate", None)
+    out_dir = getattr(args, "reporting_dir", None)
 
     if len(data) > 0:
         logger.debug("Report Info:\n%s" % data)
@@ -121,6 +124,9 @@ def report(data, heads, args):
             if cli_out:
                 fancy_out(data, heads)
                 logger.info("Fancy output")
+            elif excavate is not None and name and out_dir:
+                csv_file(data, heads, os.path.join(out_dir, f"{name}.csv"))
+                logger.info("Output to CSV file")
     else:
         msg = "No results found!\n"
         if cli_out:

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -165,7 +165,7 @@ def successful(creds, search, args):
 
     if msg:
         print(msg)
-    output.report(data, headers, args)
+    output.report(data, headers, args, name="credential_success")
 
 def successful_cli(client, args, sysuser, passwd, reporting_dir):
     credentials = access.remote_cmd('tw_vault_control --show --json -u %s -p %s'%(sysuser,passwd),client)
@@ -546,7 +546,7 @@ def devices(twsearch, twcreds, args):
 
     if msg:
         print(msg)
-    output.report(data, headers, args)
+    output.report(data, headers, args, name="devices")
 
 def ipaddr(search, credentials, args):
     ipaddr = args.excavate[1]
@@ -1032,7 +1032,7 @@ def discovery_access(twsearch, twcreds, args):
         print(msg)
         logger.error(msg)
 
-    output.report(data, headers, args)
+    output.report(data, headers, args, name="discovery_access")
 
 def discovery_analysis(twsearch, twcreds, args):
     print("\nDiscovery Access Analysis")
@@ -1407,7 +1407,7 @@ def discovery_analysis(twsearch, twcreds, args):
         print(msg)
         logger.error(msg)
 
-    output.report(data, headers, args)
+    output.report(data, headers, args, name="discovery_analysis")
 
 def tpl_export(search, query, dir, method, client, sysuser, syspass):
     tpldir = dir + "/tpl"

--- a/dismal.py
+++ b/dismal.py
@@ -184,6 +184,7 @@ if args.target:
         reporting_dir = pwd + "/output_" + args.target.replace(".","_")
     if not os.path.exists(reporting_dir):
         os.makedirs(reporting_dir)
+    args.reporting_dir = reporting_dir
 
 logging.basicConfig(level=logging.INFO, filename=logfile, filemode='w', force=True)
 logger = logging.getLogger("_dismal_")
@@ -574,7 +575,7 @@ if args.access_method=="api":
         data = []
         for identity in identities:
             data.append([identity['originating_endpoint'],identity['list_of_ips'],identity['list_of_names']])
-        output.report(data, [ "Origating Endpoint", "List of IPs", "List of Names" ], args)
+        output.report(data, [ "Origating Endpoint", "List of IPs", "List of Names" ], args, name="device_ids")
 
     if args.excavate and args.excavate[0] == "ipaddr":
         reporting.ipaddr(search, creds, args)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -30,7 +30,7 @@ class DummySearch:
 def test_overlapping_handles_bad_api(monkeypatch):
     called = {}
 
-    def fake_report(data, headers, args):
+    def fake_report(*a, **k):
         called["ran"] = True
 
     monkeypatch.setattr(builder, "output", types.SimpleNamespace(report=fake_report))

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -33,7 +33,7 @@ def _run_with_patches(monkeypatch, func):
     monkeypatch.setattr(reporting.api, "search_results", lambda *a, **k: [])
     monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
     called = {}
-    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda d, h, a: called.setdefault("ran", True)))
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda *a, **k: called.setdefault("ran", True)))
     args = types.SimpleNamespace(output_csv=False, output_file=None)
     func(DummySearch(), DummyCreds(), args)
     assert "ran" in called


### PR DESCRIPTION
## Summary
- add `args.reporting_dir` to record output directory
- allow `output.report()` to write CSV by default for excavation
- pass report names for excavate reports
- update tests for new `output.report` signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b148dcf883268c8e8a51f23e5194