### PR TITLE
Add outpost URL mapping to credential success

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -9,6 +9,7 @@ import os
 # PIP Modules
 from pprint import pprint
 import pandas
+import tideway
 
 # Local
 from . import tools, output, builder, queries, defaults, reporting
@@ -254,7 +255,45 @@ def query(search, args):
         print(msg)
         logger.warning(msg)
 
-def success(twcreds,twsearch,args,dir):
+def get_outposts(appliance):
+    """Return list of Discovery Outposts from the appliance."""
+    logger.debug("Calling appliance.get('/discovery/outposts')")
+    resp = appliance.get("/discovery/outposts")
+    logger.debug(
+        "outposts response ok=%s status=%s text=%s",
+        getattr(resp, "ok", "N/A"),
+        getattr(resp, "status_code", "N/A"),
+        getattr(resp, "text", "N/A"),
+    )
+    return get_json(resp)
+
+
+def map_outpost_credentials(appliance):
+    """Return mapping of credential UUIDs to outpost URLs."""
+    mapping = {}
+    outposts = get_outposts(appliance)
+    if not isinstance(outposts, list):
+        return mapping
+    token = getattr(appliance, "token", None)
+    for outpost in outposts:
+        url = outpost.get("url")
+        if not url:
+            continue
+        try:
+            op_app = tideway.appliance(url, token)
+            creds_ep = op_app.credentials()
+            cred_list = get_json(creds_ep.get_vault_credentials)
+            for cred in cred_list or []:
+                uuid = cred.get("uuid")
+                if not uuid:
+                    continue
+                get_json(creds_ep.get_vault_credential(uuid))
+                mapping[uuid] = url
+        except Exception as e:  # pragma: no cover - network errors
+            logger.error("Error processing outpost %s: %s", url, e)
+    return mapping
+
+def success(twcreds, twsearch, args, dir):
     reporting.successful(twcreds, twsearch, args)
     #if args.output_file:
     #    df = pandas.read_csv(args.output_file)

--- a/core/builder.py
+++ b/core/builder.py
@@ -14,6 +14,7 @@ def get_credentials(entry):
     label = entry.get('label')
     enabled = entry.get('enabled')
     types = entry.get('types')
+    usage = entry.get('usage')
     username = None
     if 'username' in entry:
         username = entry.get('username')
@@ -29,7 +30,7 @@ def get_credentials(entry):
         iprange = entry.get('ip_range')
     if 'ip_exclusion' in entry:
         exclusions = entry.get('ip_exclusion')
-    details = {"index":index,"uuid":uuid,"label":label,"username":username,"enabled":enabled,"iprange":iprange,"exclusions":exclusions,"types":types}
+    details = {"index":index,"uuid":uuid,"label":label,"username":username,"enabled":enabled,"iprange":iprange,"exclusions":exclusions,"types":types,"usage":usage}
     return details
 
 def get_credential(twsearch, twcreds, args):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -32,9 +32,10 @@ def _run_with_patches(monkeypatch, func):
     monkeypatch.setattr(reporting.builder, "unique_identities", lambda s: [])
     monkeypatch.setattr(reporting.api, "search_results", lambda *a, **k: [])
     monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.api, "map_outpost_credentials", lambda *a, **k: {})
     called = {}
     monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda *a, **k: called.setdefault("ran", True)))
-    args = types.SimpleNamespace(output_csv=False, output_file=None)
+    args = types.SimpleNamespace(output_csv=False, output_file=None, token=None, target="http://x")
     func(DummySearch(), DummyCreds(), args)
     assert "ran" in called
 
@@ -62,6 +63,6 @@ def test_successful_runs_without_scan_data(monkeypatch):
     monkeypatch.setattr(reporting.builder, "get_scans", lambda *a, **k: [])
     called = {}
     monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda *a, **k: called.setdefault("ran", True)))
-    args = types.SimpleNamespace(output_csv=False, output_file=None)
+    args = types.SimpleNamespace(output_csv=False, output_file=None, token=None, target="http://x")
     reporting.successful(DummyCreds(), DummySearch(), args)
     assert "ran" in called


### PR DESCRIPTION
## Summary
- extend `builder.get_credentials` to include `usage`
- add helper API functions to retrieve outpost URLs and map credentials
- include outpost URL and usage in credential success reports
- pass appliance object when invoking the success report so that outpost information can be retrieved
- remove appliance parameter from `success` wrapper to rely on `args.target`
- update tests for new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881f77473fc8326af4ddd93144ca416