### PR TITLE
Add outpost path test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k
 sys.modules.setdefault("tideway", types.SimpleNamespace())
 sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from core.api import get_json, search_results, show_runs
+from core.api import get_json, search_results, show_runs, get_outposts
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -56,3 +56,19 @@ def test_show_runs_handles_bad_response(capsys):
 
     captured = capsys.readouterr()
     assert "No runs in progress." in captured.out
+
+
+def test_get_outposts_uses_deleted_false():
+    """Verify get_outposts calls the correct API path."""
+    class DummyAppliance:
+        def __init__(self):
+            self.requested = None
+
+        def get(self, path):
+            self.requested = path
+            return DummyResponse(200, "[]")
+
+    app = DummyAppliance()
+    get_outposts(app)
+
+    assert app.requested == "/discovery/outposts?deleted=false"


### PR DESCRIPTION
## Summary
- check get_outposts uses deleted=false query parameter

## Testing
- `pytest -q` *(fails: assert '/discovery/outposts' == '/discovery/outposts?deleted=false')*

------
https://chatgpt.com/codex/tasks/task_e_688205b692848326b89677e2758cb8a6