### PR TITLE
Improve outpost credential mapping

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -5,6 +5,7 @@ import logging
 import csv
 import json
 import os
+from urllib.parse import urlparse
 
 # PIP Modules
 from pprint import pprint
@@ -280,8 +281,10 @@ def map_outpost_credentials(appliance):
         url = outpost.get("url")
         if not url:
             continue
+        parsed = urlparse(url)
+        target = (parsed.netloc or parsed.path).rstrip("/")
         try:
-            op_app = tideway.appliance(url, token, api_version=api_version)
+            op_app = tideway.outpost(target, token, api_version=api_version)
             creds_ep = op_app.credentials()
             cred_list = get_json(creds_ep.get_vault_credentials)
             for cred in cred_list or []:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,8 @@ sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k
 sys.modules.setdefault("tideway", types.SimpleNamespace())
 sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from core.api import get_json, search_results, show_runs, get_outposts
+from core.api import get_json, search_results, show_runs, get_outposts, map_outpost_credentials
+import core.api as api_mod
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -71,3 +72,35 @@ def test_get_outposts_uses_deleted_false():
     get_outposts(app)
 
     assert app.requested == "/discovery/outposts?deleted=false"
+
+
+def test_map_outpost_credentials_strips_scheme(monkeypatch):
+    """Outpost targets should not include protocol."""
+
+    def fake_get_outposts(app):
+        return [{"url": "https://op.example.com"}]
+
+    class DummyCreds:
+        def get_vault_credentials(self):
+            return DummyResponse(200, '[{"uuid": "u1"}]')
+        def get_vault_credential(self, uuid):
+            return DummyResponse(200, "{}")
+
+    class DummyOutpost:
+        def credentials(self):
+            return DummyCreds()
+
+    captured = {}
+
+    def fake_outpost(target, token, api_version=None, ssl_verify=None, limit=None, offset=None):
+        captured["target"] = target
+        return DummyOutpost()
+
+    monkeypatch.setattr(api_mod, "get_outposts", fake_get_outposts)
+    monkeypatch.setattr(api_mod.tideway, "outpost", fake_outpost, raising=False)
+
+    mapping = map_outpost_credentials(types.SimpleNamespace(token="t"))
+
+    assert captured["target"] == "op.example.com"
+    assert mapping == {"u1": "https://op.example.com"}
+


### PR DESCRIPTION
## Summary
- query outposts using `tideway.outpost`
- strip protocol from outpost URLs
- test scheme stripping in map_outpost_credentials

## Testing
- `pip install cidrize`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822f1544188326b8f78627e499b210