### PR TITLE
Add instance column to credential success report

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -269,6 +269,11 @@ def successful(creds, search, args):
             ]
     print(os.linesep,end="\r")
 
+    if data:
+        headers.insert(0, "Discovery Instance")
+        for row in data:
+            row.insert(0, getattr(args, "target", None))
+
     if msg:
         print(msg)
     output.report(data, headers, args, name="credential_success")


### PR DESCRIPTION
## Summary
- prepend instance name to each credential success row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882332bb0208326ba2cbb1bb4ee0fc8