### PR TITLE
Refactor discovery reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ and tideway password from files instead of providing them inline.
 By default, reports are written to an `output_<appliance>` directory in the
 current working directory. Use the `--stdout` option to suppress file output and
 print results directly to the terminal.
+
+## Reports
+
+Two related reports focus on Discovery Access history:
+
+- **discovery_access** – exports the latest access details for each endpoint,
+  including credential information and timestamps.
+- **discovery_analysis** – adds a comparison between consecutive runs using the
+  same data to highlight state changes.


### PR DESCRIPTION
## Summary
- deduplicate discovery_analysis implementation
- provide helper to gather raw discovery access data
- trim discovery_access to export raw data
- compare consecutive runs in discovery_analysis
- document reporting functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688790c12d888326a08b0dbd4a9d17d0