### PR TITLE
Fix schedules when API already parsed

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -90,6 +90,8 @@ def get_json(api_endpoint):
             return {}
 
     if not hasattr(api_endpoint, "status_code"):
+        if isinstance(api_endpoint, (list, dict)):
+            return api_endpoint
         logger.error("Invalid API endpoint provided to get_json")
         return {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,15 @@ def test_get_json_bad_json():
     resp = DummyResponse(200, 'not-json')
     assert get_json(resp) == {}
 
+def test_get_json_returns_list_directly():
+    data = [{"x": 1}]
+    # When a list is passed in, get_json should return it unchanged
+    assert get_json(data) == data
+
+def test_get_json_returns_dict_directly():
+    data = {"a": 1}
+    assert get_json(data) == data
+
 def test_search_results_fallback():
     resp = DummyResponse(200, '[{"ok": true}]')
     search = DummySearch(resp)


### PR DESCRIPTION
## Summary
- avoid error when API search results are already decoded
- test `get_json` with list and dict inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889d4e89508326a567c1922fc8f1c3