### PR TITLE
Sanitize dict queries in search_results

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -659,8 +659,12 @@ def update_cred(appliance, uuid):
             active = True
     return active
 
-def search_results(api_endpoint,query):
+def search_results(api_endpoint, query):
     try:
+        if isinstance(query, dict) and "query" in query:
+            sanitized = query["query"].replace("'", '\\"')
+            sanitized = sanitized.replace("\n", " ").replace("\r", " ")
+            query = {"query": sanitized}
         if logger.isEnabledFor(logging.DEBUG):
             try:
                 logger.debug("Search query: %s" % query)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,22 @@ def test_search_results_fallback():
     assert search_results(search, {"query": "q"}) == [{"ok": True}]
 
 
+def test_search_results_sanitizes_dict_query():
+    captured = {}
+
+    class CaptureSearch:
+        def search(self, query, format="object", limit=500):
+            captured["q"] = query
+            return DummyResponse(200, "[]")
+
+    search = CaptureSearch()
+    query = {"query": "search Foo\nshow bar as 'Bar'"}
+
+    search_results(search, query)
+
+    assert captured["q"] == {"query": 'search Foo show bar as \\"Bar\\"'}
+
+
 def test_show_runs_handles_bad_response(capsys):
     resp = DummyResponse(401, 'not-json', reason="Unauthorized")
     disco = DummyDisco(resp)


### PR DESCRIPTION
## Summary
- sanitize multi-line dict queries before hitting the API
- verify sanitization behavior in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b308929083269ca85e090a35a344