### PR TITLE
Improve search_results error handling

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -680,6 +680,20 @@ def search_results(api_endpoint,query):
                     logger.debug("Raw search response: %s" % results.text)
                 except Exception:
                     pass
+
+            status_code = getattr(results, "status_code", 200)
+            if status_code >= 400:
+                try:
+                    data = json.loads(results.text)
+                except Exception:
+                    data = {"error": getattr(results, "text", "")}
+                if logger.isEnabledFor(logging.DEBUG):
+                    try:
+                        logger.debug("Parsed error payload: %s" % json.dumps(data))
+                    except Exception:
+                        pass
+                return data
+
             try:
                 data = results.json()
             except Exception as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ class DummyResponse:
         self.reason = reason
         self.url = url
         self.ok = status_code == 200
+        self.text = data
     def json(self):
         import json
         return json.loads(self._data)
@@ -55,6 +56,18 @@ def test_search_results_fallback():
     resp = DummyResponse(200, '[{"ok": true}]')
     search = DummySearch(resp)
     assert search_results(search, {"query": "q"}) == [{"ok": True}]
+
+
+def test_search_results_error_json():
+    resp = DummyResponse(404, '{"error": "missing"}')
+    search = DummySearch(resp)
+    assert search_results(search, {"query": "q"}) == {"error": "missing"}
+
+
+def test_search_results_error_non_json():
+    resp = DummyResponse(500, 'Internal Server Error')
+    search = DummySearch(resp)
+    assert search_results(search, {"query": "q"}) == {"error": "Internal Server Error"}
 
 
 def test_show_runs_handles_bad_response(capsys):


### PR DESCRIPTION
## Summary
- parse and return error payloads for search_results
- test error handling for search_results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b309b7f4832682370fc1074973e8