### PR TITLE
Add sanitization and error path tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,3 +113,33 @@ def test_map_outpost_credentials_strips_scheme(monkeypatch):
     assert captured["target"] == "op.example.com"
     assert mapping == {"u1": "https://op.example.com"}
 
+
+def test_search_results_cleans_query(monkeypatch):
+    """Ensure single quotes become escaped double quotes and newlines removed."""
+
+    captured = {}
+
+    class Recorder:
+        def search(self, query, format="object", limit=500):
+            captured["query"] = query
+            return DummyResponse(200, "[]")
+
+    qry = "search Device\nwhere name = 'foo'\n"
+    search_results(Recorder(), {"query": qry})
+
+    sent = captured["query"]["query"]
+    assert "'" not in sent
+    assert "\n" not in sent
+    assert '\\"foo\\"' in sent
+
+
+def test_search_results_returns_error_payload(caplog):
+    resp = DummyResponse(400, '{"msg": "bad"}', reason="Bad")
+    search = DummySearch(resp)
+
+    with caplog.at_level("ERROR"):
+        result = search_results(search, {"query": "q"})
+
+    assert result == {"msg": "bad"}
+    assert "Bad" in caplog.text
+


### PR DESCRIPTION
## Summary
- clean query strings before search
- log and return JSON payload on search errors
- add tests for query sanitization and API error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b30acd708326a4e8838030102a38