### PR TITLE
Handle table results from search_results

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -701,6 +701,7 @@ def search_results(api_endpoint, query):
                         logger.debug("Parsed error payload: %s" % json.dumps(data))
                     except Exception:
                         pass
+                logger.error("Search failed: %s - %s", status_code, getattr(results, "reason", ""))
                 return data
             try:
                 data = results.json()
@@ -715,14 +716,14 @@ def search_results(api_endpoint, query):
                         logger.debug("Parsed results length: %s" % len(data))
                     except Exception:
                         pass
-                return data
+                return tools.list_table_to_json(data)
         else:
             if logger.isEnabledFor(logging.DEBUG):
                 try:
                     logger.debug("Parsed results length: %s" % len(results))
                 except Exception:
                     pass
-            return results
+            return tools.list_table_to_json(results)
     except Exception as e:
         msg = "Not able to make api call.\nQuery: %s\nException: %s\n%s" %(query,e.__class__,str(e))
         print(msg)

--- a/core/tools.py
+++ b/core/tools.py
@@ -206,3 +206,14 @@ def json2csv(jsdata):
             values.append(getr(jsitem,key,"N/A")) # Substitute if missing
         data.append(values)
     return header, data
+
+def list_table_to_json(rows):
+    """Convert a list-of-lists table to a list of dictionaries.
+
+    The first row is treated as headers.  If ``rows`` is not a list of
+    lists, the value is returned unchanged.
+    """
+    if isinstance(rows, list) and rows and isinstance(rows[0], list):
+        headers = rows[0]
+        return [dict(zip(headers, r)) for r in rows[1:]]
+    return rows

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,3 +155,9 @@ def test_search_results_returns_error_payload(caplog):
     assert result == {"msg": "bad"}
     assert "Bad" in caplog.text
 
+
+def test_search_results_list_table():
+    search = DummySearch([["A", "B"], [1, 2]])
+    result = search_results(search, {"query": "q"})
+    assert result == [{"A": 1, "B": 2}]
+


### PR DESCRIPTION
## Summary
- add `list_table_to_json` utility to turn a list-of-lists into list of dicts
- update `search_results` to parse tabular output and log error responses
- test table conversion in the API helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cfe23d388326b750215d1d82e335