### PR TITLE
Fix excludes query dict usage

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -692,13 +692,20 @@ def search_results(api_endpoint, query):
                     pass
             status_code = getattr(results, "status_code", 200)
             if status_code >= 400:
+                logger.error(
+                    "Search API returned %s - %s",
+                    status_code,
+                    getattr(results, "reason", ""),
+                )
                 try:
                     data = json.loads(results.text)
                 except Exception:
                     data = {"error": getattr(results, "text", "")}
                 if logger.isEnabledFor(logging.DEBUG):
                     try:
-                        logger.debug("Parsed error payload: %s" % json.dumps(data))
+                        logger.debug(
+                            "Parsed error payload: %s" % json.dumps(data)
+                        )
                     except Exception:
                         pass
                 return data

--- a/core/queries.py
+++ b/core/queries.py
@@ -93,14 +93,12 @@ da_ip_lookup = {
                                 #::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.ip_addr as 'NIC_IPs'
                             """
                 }
-excludes = {"""
-                        search in '_System' ExcludeRange
-                        show
-                        exrange_id as 'ID',
-                        name as 'Label',
-                        range_strings as 'Scan_Range',
-                        recurrenceDescription(schedule) as 'Date_Rules'
-                    """}
+excludes = {"query": """search in '_System' ExcludeRange
+                            show
+                            exrange_id as 'ID',
+                            name as 'Label',
+                            range_strings as 'Scan_Range',
+                            recurrenceDescription(schedule) as 'Date_Rules'"""}
 scanrange = {
                 "query":
                 """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.api import get_json, search_results, show_runs, get_outposts, map_outpost_credentials
 import core.api as api_mod
+from core import queries
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -154,4 +155,21 @@ def test_search_results_returns_error_payload(caplog):
 
     assert result == {"msg": "bad"}
     assert "Bad" in caplog.text
+
+
+def test_excludes_query_dict(monkeypatch):
+    """search_results should accept the excludes dict query."""
+
+    captured = {}
+
+    class Recorder:
+        def search(self, query, format="object", limit=500):
+            captured["query"] = query
+            return DummyResponse(200, "[]")
+
+    result = search_results(Recorder(), queries.excludes)
+
+    assert result == []
+    assert isinstance(captured["query"], dict)
+    assert "query" in captured["query"]
 


### PR DESCRIPTION
## Summary
- correct `excludes` query to be a dict with `query` key
- log an error when the search API returns an error
- add unit test ensuring `queries.excludes` works with `search_results`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cfe41d688326937430fd55cdbc21