### PR TITLE
Implement timezone schedule update

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -109,6 +109,11 @@ administration.add_argument('--cred_optimise',      dest='a_opt', action='store_
 administration.add_argument('--cred_remove',        dest='a_removal', type=str, required=False, help='Delete a credential from the system (with prompt).\n\n',metavar='<UUID>')
 administration.add_argument('--cred_remove_list',   dest='f_remlist', type=str, required=False, help='Specify a list of credentials to delete (no prompt).\n\n',metavar='<filename>')
 administration.add_argument('--kill_run',           dest='a_kill_run', type=str, required=False, help='Nicely kill a discovery run that is jammed.\n\n',metavar='<argument>')
+administration.add_argument('--schedule_timezone',  dest='schedule_timezone', type=str, required=False,
+                           help='Timezone to apply to discovery run schedules (e.g. CST or America/Chicago).\n\n',
+                           metavar='<timezone>')
+administration.add_argument('--reset_schedule_timezone', dest='reset_schedule_timezone', action='store_true', required=False,
+                           help='With --schedule_timezone, shift scheduled times back to UTC.\n\n')
 
 # Excavation (Boosted Reports)
 excavation = parser.add_argument_group("Excavation (Boosted Reports)")
@@ -565,6 +570,9 @@ if args.access_method=="api":
         
     if args.a_kill_run:
         api.cancel_run(disco, args)
+
+    if args.schedule_timezone:
+        api.update_schedule_timezone(disco, args)
 
     if args.excavate and args.excavate[0] == "device":
         builder.get_device(search, creds, args)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import json
 
 sys.modules.setdefault("pandas", types.SimpleNamespace())
 sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
@@ -35,6 +36,15 @@ class DummyDisco:
     @property
     def get_discovery_runs(self):
         return self._response
+
+class RecorderDisco(DummyDisco):
+    def __init__(self, response):
+        super().__init__(response)
+        self.patches = []
+
+    def patch_discovery_run(self, rid, payload):
+        self.patches.append((rid, payload))
+        return DummyResponse(200, "{}")
 
 def test_get_json_success():
     resp = DummyResponse(200, '{"a":1}')
@@ -160,4 +170,26 @@ def test_search_results_list_table():
     search = DummySearch([["A", "B"], [1, 2]])
     result = search_results(search, {"query": "q"})
     assert result == [{"A": 1, "B": 2}]
+
+
+def test_update_schedule_timezone_applies_offset():
+    runs = [{"range_id": "r1", "schedule": {"start_times": [10, 23]}}]
+    resp = DummyResponse(200, json.dumps(runs))
+    disco = RecorderDisco(resp)
+    args = types.SimpleNamespace(schedule_timezone="Etc/GMT+5", reset_schedule_timezone=False)
+
+    api_mod.update_schedule_timezone(disco, args)
+
+    assert disco.patches == [("r1", {"schedule": {"start_times": [5, 18]}})]
+
+
+def test_update_schedule_timezone_reset():
+    runs = [{"range_id": "r1", "schedule": {"start_times": [10]}}]
+    resp = DummyResponse(200, json.dumps(runs))
+    disco = RecorderDisco(resp)
+    args = types.SimpleNamespace(schedule_timezone="Etc/GMT+5", reset_schedule_timezone=True)
+
+    api_mod.update_schedule_timezone(disco, args)
+
+    assert disco.patches[0][1]["schedule"]["start_times"] == [15]
 


### PR DESCRIPTION
## Summary
- allow adjusting discovery run schedules to a new timezone
- add CLI options `--schedule_timezone` and `--reset_schedule_timezone`
- patch discovery runs with shifted start times
- test timezone update logic

## Testing
- `pip install cidrize`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a01f305788326b748b7f9a868d103