### PR TITLE
Fix unique_identities error handling

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -267,3 +267,15 @@ def test_overlapping_empty_scan_ranges(monkeypatch, capsys):
 
     assert "No scan ranges found" in out
 
+
+def test_unique_identities_handles_bad_api(monkeypatch):
+    monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)
+
+    def fake_search_results(api, query):
+        return {"error": "fail"}
+
+    monkeypatch.setattr(builder.api, "search_results", fake_search_results)
+
+    result = builder.unique_identities(None)
+    assert result == []
+


### PR DESCRIPTION
## Summary
- guard against invalid results from `search_results` in `unique_identities`
- skip malformed discovery access and device records
- add regression test covering error case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b213ae5a883269569f848b6b73184