### PR TITLE
Fix discovery_access bins initialization

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -855,6 +855,18 @@ def _gather_discovery_data(twsearch, twcreds):
 
     unique_endpoints = tools.sortlist(unique_endpoints)
 
+    bins = [0, 59, 1440, 10080, 43830, 131487, 262974, 525949, 525950]
+    labels = [
+        "Less than 60 minutes ago",
+        "Less than 24 hours ago",
+        "Less than 7 days ago",
+        "Less than 1 month ago",
+        "Less than 3 months ago",
+        "Less than 6 months ago",
+        "Less than 12 months ago",
+        "Over a year ago",
+    ]
+
     timer_count = 0
     for endpoint in unique_endpoints:
         timer_count = tools.completage(
@@ -887,17 +899,6 @@ def _gather_discovery_data(twsearch, twcreds):
                 delta = time_now - ep_timestamp
                 overall_mins = delta.days * 24 * 60 + (delta.seconds) / 60
                 whenData = pd.DataFrame({"in_minutes": [overall_mins]})
-                bins = [0, 59, 1440, 10080, 43830, 131487, 262974, 525949, 525950]
-                labels = [
-                    "Less than 60 minutes ago",
-                    "Less than 24 hours ago",
-                    "Less than 7 days ago",
-                    "Less than 1 month ago",
-                    "Less than 3 months ago",
-                    "Less than 6 months ago",
-                    "Less than 12 months ago",
-                    "Over a year ago",
-                ]
                 whenData["when"] = pd.cut(
                     whenData["in_minutes"], bins=bins, labels=labels, right=False
                 )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -100,3 +100,41 @@ def test_successful_uses_token_file(monkeypatch, tmp_path):
     reporting.successful(DummyCreds(), DummySearch(), args)
 
     assert captured["token"] == "abc"
+
+
+def test_discovery_access_with_dropped_only(monkeypatch):
+    class DummyDF(dict):
+        def __init__(self, data):
+            super().__init__({k: {0: v[0] if isinstance(v, list) else v} for k, v in data.items()})
+
+        def __getitem__(self, key):
+            return self.get(key)
+
+        def __setitem__(self, key, value):
+            dict.__setitem__(self, key, {0: value})
+
+        def to_dict(self):
+            return self
+
+    monkeypatch.setattr(reporting.builder, "unique_identities", lambda s: [])
+
+    def fake_search_results(search, query):
+        if query is reporting.queries.last_disco:
+            return []
+        if query is reporting.queries.dropped_endpoints:
+            return [{"Endpoint": "1.2.3.4", "End": "2024-01-01 00:00:00", "Run": "r", "Start": "2024-01-01 00:00:00", "End_State": "DarkSpace"}]
+        return []
+
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.api, "map_outpost_credentials", lambda *a, **k: {})
+    monkeypatch.setattr(reporting.pd, "DataFrame", lambda data: DummyDF(data), raising=False)
+    monkeypatch.setattr(reporting.pd, "cut", lambda *a, **k: "recent", raising=False)
+
+    called = {}
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=lambda *a, **k: called.setdefault("ran", True)))
+    args = types.SimpleNamespace(output_csv=False, output_file=None, token=None, target="http://x")
+
+    reporting.discovery_access(DummySearch(), DummyCreds(), args)
+
+    assert "ran" in called


### PR DESCRIPTION
## Summary
- ensure `_gather_discovery_data` initializes `bins` and `labels` before loops
- remove duplicate bin/label setup inside loop
- add regression test for dropped-endpoint data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b302b88b0832690975446e4b63060