### PR TITLE
Fix search API escaping issue

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -736,8 +736,7 @@ def update_cred(appliance, uuid):
 def search_results(api_endpoint, query):
     try:
         if isinstance(query, dict) and "query" in query:
-            sanitized = query["query"].replace("'", '\\"')
-            sanitized = sanitized.replace("\n", " ").replace("\r", " ")
+            sanitized = query["query"].replace("\n", " ").replace("\r", " ")
             query = {"query": sanitized}
         if logger.isEnabledFor(logging.DEBUG):
             try:
@@ -746,7 +745,7 @@ def search_results(api_endpoint, query):
                 pass
 
         if isinstance(query, dict) and isinstance(query.get("query"), str):
-            cleaned = query["query"].replace("\n", " ").replace("'", r'\"')
+            cleaned = query["query"].replace("\n", " ").replace("\r", " ")
             query = dict(query)
             query["query"] = cleaned
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ def test_map_outpost_credentials_strips_scheme(monkeypatch):
 
 
 def test_search_results_cleans_query(monkeypatch):
-    """Ensure single quotes become escaped double quotes and newlines removed."""
+    """Ensure newlines removed and single quotes preserved."""
 
     captured = {}
 
@@ -151,9 +151,9 @@ def test_search_results_cleans_query(monkeypatch):
     search_results(Recorder(), {"query": qry})
 
     sent = captured["query"]["query"]
-    assert "'" not in sent
     assert "\n" not in sent
-    assert '\\"foo\\"' in sent
+    assert "'foo'" in sent
+    assert '\\"foo\\"' not in sent
 
 
 def test_search_results_returns_error_payload(caplog):


### PR DESCRIPTION
## Summary
- stop escaping single quotes when building search queries
- update tests for new query behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6bd7db208326814f9066f34fb246