### PR TITLE
Replace os.system ping with subprocess

### DIFF
--- a/core/access.py
+++ b/core/access.py
@@ -5,6 +5,7 @@ import os
 import sys
 import platform
 import getpass
+import subprocess
 
 # PIP Packages
 import tideway
@@ -43,18 +44,18 @@ def ping(target):
     current_os = platform.system().lower()
     if current_os == "windows":
         parameters = "-n 1 -w 2"
-        null = "$null"
     elif current_os == "linux":
         parameters = "-c 1 -w2"
-        null = "/dev/null"
     else: # Mac
         parameters = "-c 1 -i2"
-        null = "/dev/null"
-    exit_code = os.system(f"ping {parameters} {target} > {null} 2>&1")
-    if os.path.exists("$null"):
-        # Windows outputs to a '$null' file instead of Null
-        os.remove("$null")
-    return exit_code
+
+    result = subprocess.run(
+        ["ping", parameters, target],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    return result.returncode
 
 def run_cmd(cmd, client):
     stdin, stdout, stderr = client.exec_command(cmd)


### PR DESCRIPTION
## Summary
- avoid using `os.system` for ping
- use `subprocess.run` instead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c011221c08326840ce1ada12c24e4