### PR TITLE
refactor: use getattr for show_runs options

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -366,14 +366,16 @@ def show_runs(disco, args):
             run_csv.append(value)
         run_csvs.append(run_csv)
     run_csvs.insert(0, headers)
-    if args.export:
+    export = getattr(args, "export", False)
+    outfile = getattr(args, "file", getattr(args, "output_file", None))
+    if export:
         w = csv.writer(sys.stdout)
         w.writerows(run_csvs)
-    elif args.file:
-        with open(args.file, "w", newline="") as file:
+    elif outfile:
+        with open(outfile, "w", newline="") as file:
             writer = csv.writer(file)
             writer.writerows(run_csvs)
-            msg = "Results written to %s" % args.file
+            msg = "Results written to %s" % outfile
             print(msg)
             logger.info(msg)
     else:


### PR DESCRIPTION
## Summary
- use `getattr` to fetch `export` and output file options in `show_runs`
- streamline run export logic based on local variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a2df80d08326b76acdeb56367d95