### PR TITLE
Add test for show_runs minimal args

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -366,10 +366,10 @@ def show_runs(disco, args):
             run_csv.append(value)
         run_csvs.append(run_csv)
     run_csvs.insert(0, headers)
-    if args.export:
+    if getattr(args, "export", False):
         w = csv.writer(sys.stdout)
         w.writerows(run_csvs)
-    elif args.file:
+    elif getattr(args, "file", None):
         with open(args.file, "w", newline="") as file:
             writer = csv.writer(file)
             writer.writerows(run_csvs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,18 @@ def test_show_runs_handles_bad_response(capsys):
     captured = capsys.readouterr()
     assert "No runs in progress." in captured.out
 
+
+def test_show_runs_minimal_args(capsys):
+    """show_runs should handle args without optional attributes."""
+    resp = DummyResponse(401, 'not-json', reason="Unauthorized")
+    disco = DummyDisco(resp)
+    args = types.SimpleNamespace()
+
+    show_runs(disco, args)
+
+    captured = capsys.readouterr()
+    assert "No runs in progress." in captured.out
+
 def test_get_outposts_uses_deleted_false():
     """Verify get_outposts calls the correct API path."""
     class DummyAppliance:


### PR DESCRIPTION
## Summary
- ensure `show_runs` tolerates missing `export`/`file` args
- test `show_runs` with empty `SimpleNamespace`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a2e324188326a1a72eed5545ca7a