### PR TITLE
Switch to network objects for IP ranges

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -21,55 +21,44 @@ def getr(data,attribute,default_value=None):
     return data.get(attribute) or default_value
 
 def range_to_ips(iprange):
-    list_of_ips = []
-    logger.info("Running range_to_ips function on %s"%iprange)
+    """Return a list of :class:`ipaddress.IPv4Network`/`IPv6Network` objects.
+
+    The previous implementation expanded ranges into individual IP addresses
+    which was expensive for large networks.  This helper now preserves the
+    ranges and returns ``ip_network`` objects instead.  Cloud end points and
+    the special "all" range are returned unchanged as strings.
+    """
+
+    networks = []
+    logger.info("Running range_to_ips function on %s" % iprange)
     if not iprange:
-        # Return empty list
-        return list_of_ips
-    if re.search('[a-zA-Z]', iprange):
+        return networks
+
+    if re.search("[a-zA-Z]", iprange):
         logger.debug("IP range is cloud endpoint!")
-        list_of_ips.append(iprange)
+        networks.append(iprange)
     elif iprange == "0.0.0.0/0,::/0":
-        list_of_ips.append(iprange)
-        logger.debug("All - List of IPs: %s"%list_of_ips)
-    elif iprange:
-        iprange = [ip for ip in iprange.split(",") if ip]
-        #timer_count = 0
-        for ip in iprange:
-            #timer_count = Transform.completage("Processing IP Range", len(iprange), timer_count)
+        networks.append(iprange)
+        logger.debug("All - List of Networks: %s" % networks)
+    else:
+        parts = [ip for ip in iprange.split(",") if ip]
+        for ip in parts:
             try:
-                ipaddr = ipaddress.ip_address(ip)
-                list_of_ips.append(ipaddr)
-                logger.debug("Single - List of IPs: %s"%list_of_ips)
-            except:
+                net = ipaddress.ip_network(ip, strict=False)
+                networks.append(net)
+                logger.debug("Network appended: %s", net)
+            except Exception:
                 try:
-                    subnet = ipaddress.ip_network(ip)
-                    for ipaddr in subnet:
-                        list_of_ips.append(ipaddr)
-                        logger.debug("Subnet - List of IPs: %s"%list_of_ips)
-                except:
-                    try:
-                        subnet = ipaddress.ip_network(ip,strict=False)
-                        msg = 'Address %s is not valid CIDR syntax, recommended CIDR: %s' % (ip, subnet)
-                        print(msg)
-                        logger.warning(msg)
-                        for ipaddr in subnet:
-                            list_of_ips.append(ipaddr)
-                            logger.debug("Subnet (not strict) - List of IPs: %s"%list_of_ips)
-                    except:
-                        try:
-                            cidrip = cidrize(ip)
-                            size = 0
-                            for cidr in cidrip:
-                                subnet = ipaddress.ip_network(cidr)
-                                for ipaddr in subnet:
-                                    list_of_ips.append(ipaddr)
-                                    logger.debug("CIDRize - List of IPs: %s"%list_of_ips)
-                        except:
-                            msg = 'Address %s is not valid CIDR syntax, cannot process!' % (ip)
-                            print(msg)
-                            logger.warning(msg)
-    return list_of_ips
+                    cidrip = cidrize(ip)
+                    for cidr in cidrip:
+                        net = ipaddress.ip_network(cidr, strict=False)
+                        networks.append(net)
+                        logger.debug("CIDRize - Network appended: %s", net)
+                except Exception:
+                    msg = "Address %s is not valid CIDR syntax, cannot process!" % ip
+                    print(msg)
+                    logger.warning(msg)
+    return networks
 
 def get_credential(data,uuid):
     credentials = data

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import ipaddress
 
 sys.modules.setdefault("pandas", types.SimpleNamespace())
 sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
@@ -78,7 +79,11 @@ def _setup_schedule_patches(monkeypatch, cred_list, excludes, scan_ranges):
     seq = iter([cred_list, excludes, scan_ranges])
 
     monkeypatch.setattr(builder.api, "get_json", lambda *a, **k: next(seq))
-    monkeypatch.setattr(builder.tools, "range_to_ips", lambda r: [r])
+    monkeypatch.setattr(
+        builder.tools,
+        "range_to_ips",
+        lambda r: [ipaddress.ip_network(r, strict=False)] if r else [],
+    )
     monkeypatch.setattr(builder.tools, "sortlist", lambda l, dv=None: list(l))
     monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)
 
@@ -102,7 +107,11 @@ def _setup_overlap_patches(monkeypatch, scan_ranges, excludes):
 
     monkeypatch.setattr(builder.api, "get_json", lambda *a, **k: next(seq))
     monkeypatch.setattr(builder.api, "search_results", lambda *a, **k: [])
-    monkeypatch.setattr(builder.tools, "range_to_ips", lambda r: [r])
+    monkeypatch.setattr(
+        builder.tools,
+        "range_to_ips",
+        lambda r: [ipaddress.ip_network(r, strict=False)] if r else [],
+    )
     monkeypatch.setattr(builder.tools, "sortdic", lambda l: list(l))
     monkeypatch.setattr(builder.tools, "sortlist", lambda l, dv=None: list(l))
     monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)
@@ -177,7 +186,11 @@ def test_scheduling_creates_empty_csv(monkeypatch):
     seq = iter([cred, [], []])
 
     monkeypatch.setattr(builder.api, "get_json", lambda *a, **k: next(seq))
-    monkeypatch.setattr(builder.tools, "range_to_ips", lambda r: [r])
+    monkeypatch.setattr(
+        builder.tools,
+        "range_to_ips",
+        lambda r: [ipaddress.ip_network(r, strict=False)] if r else [],
+    )
     monkeypatch.setattr(builder.tools, "sortlist", lambda l, dv=None: list(l))
     monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)
 
@@ -227,7 +240,11 @@ def test_overlapping_scan_ranges_no_results_key(monkeypatch):
     seq = iter([scan_ranges, excludes])
     monkeypatch.setattr(builder.api, "get_json", lambda *a, **k: next(seq))
     monkeypatch.setattr(builder.api, "search_results", lambda *a, **k: [])
-    monkeypatch.setattr(builder.tools, "range_to_ips", lambda r: [r])
+    monkeypatch.setattr(
+        builder.tools,
+        "range_to_ips",
+        lambda r: [ipaddress.ip_network(r, strict=False)] if r else [],
+    )
     monkeypatch.setattr(builder.tools, "sortdic", lambda l: list(l))
     monkeypatch.setattr(builder.tools, "sortlist", lambda l, dv=None: list(l))
     monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,17 +13,12 @@ def test_range_to_ips_empty():
 
 def test_range_to_ips_single_ip():
     result = tools.range_to_ips("192.168.1.1")
-    assert result == [ipaddress.ip_address("192.168.1.1")]
+    assert result == [ipaddress.ip_network("192.168.1.1/32")]
 
 
 def test_range_to_ips_subnet():
     result = tools.range_to_ips("192.168.1.0/30")
-    expected = [
-        ipaddress.ip_address("192.168.1.0"),
-        ipaddress.ip_address("192.168.1.1"),
-        ipaddress.ip_address("192.168.1.2"),
-        ipaddress.ip_address("192.168.1.3"),
-    ]
+    expected = [ipaddress.ip_network("192.168.1.0/30")]
     assert result == expected
 
 


### PR DESCRIPTION
## Summary
- Return `IPv4Network`/`IPv6Network` objects from `range_to_ips` instead of expanding addresses
- Use network overlap checks when matching credential ranges to scan ranges
- Test `range_to_ips` with single IPs, CIDR ranges, "all" ranges and cloud endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c8b6b9948326b495a684bdbf5448