### PR TITLE
Run credential queries in parallel

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -68,6 +68,65 @@ def test_successful_runs_without_scan_data(monkeypatch):
     assert "ran" in called
 
 
+def test_successful_combines_query_results(monkeypatch):
+    calls = []
+
+    def fake_search_results(search, query):
+        calls.append(query)
+        if query is reporting.queries.credential_success:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 2}]
+        if query is reporting.queries.deviceinfo_success:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 3}]
+        if query is reporting.queries.credential_failure:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 4}]
+        return []
+
+    call = {"n": 0}
+
+    def fake_get_json(*a, **k):
+        call["n"] += 1
+        if call["n"] == 1:
+            return [
+                {
+                    "uuid": "u1",
+                    "label": "c",
+                    "index": 1,
+                    "enabled": True,
+                    "username": "user",
+                    "usage": "",
+                    "iprange": None,
+                    "exclusions": None,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(reporting.api, "get_json", fake_get_json)
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.builder, "get_credentials", lambda entry: entry)
+    monkeypatch.setattr(reporting.builder, "get_scans", lambda *a, **k: [])
+
+    captured = {}
+
+    def fake_report(data, headers, args, name=""):
+        captured["data"] = data
+        captured["headers"] = headers
+
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=fake_report))
+
+    args = types.SimpleNamespace(output_csv=False, output_file=None, token=None, target="http://x")
+
+    reporting.successful(DummyCreds(), DummySearch(), args)
+
+    assert set(calls) == {
+        reporting.queries.credential_success,
+        reporting.queries.deviceinfo_success,
+        reporting.queries.credential_failure,
+    }
+    row = captured["data"][0]
+    assert row[6] == 5
+    assert row[7] == 4
+
+
 def test_successful_uses_token_file(monkeypatch, tmp_path):
     file_path = tmp_path / "token.txt"
     file_path.write_text("abc")


### PR DESCRIPTION
## Summary
- speed up credential success report by running three searches in parallel with ThreadPoolExecutor
- add unit test verifying all query results are combined correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891c8d571d48326b12565c20f1e84dd