### PR TITLE
refactor: guard debug JSON serialization

### DIFF
--- a/api_debug.py
+++ b/api_debug.py
@@ -216,7 +216,7 @@ def get_json(api_endpoint):
     else:
         if logger.isEnabledFor(logging.DEBUG):
             try:
-                logger.debug("Decoded JSON from %s:\n%s" % (url, json.dumps(data, indent=2)))
+                logger.debug("Decoded JSON from %s:\n%s", url, json.dumps(data, indent=2))
             except Exception:
                 pass
         return data
@@ -276,7 +276,8 @@ def success(twcreds, twsearch, args, dir):
     print("vaultcreds Type: ", type(vaultcreds))
     print("vaultcreds JSON: ", vaultcreds)
 
-    logger.debug('List Credentials:' + json.dumps(vaultcreds))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug('List Credentials: %s', json.dumps(vaultcreds))
 
     credsux_results = search_results(twsearch, queries.credential_success)
     devinfosux = search_results(twsearch, queries.deviceinfo_success)
@@ -285,9 +286,10 @@ def success(twcreds, twsearch, args, dir):
     data = []
     headers = []
 
-    logger.info('Successful SessionResults:' + json.dumps(credsux_results))
-    logger.info('Successful DeviceInfos:' + json.dumps(devinfosux))
-    logger.info('Failures:' + json.dumps(credfail_results))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug('Successful SessionResults: %s', json.dumps(credsux_results))
+        logger.debug('Successful DeviceInfos: %s', json.dumps(devinfosux))
+        logger.debug('Failures: %s', json.dumps(credfail_results))
 
     suxCreds = tools.session_get(credsux_results)
     suxDev = tools.session_get(devinfosux)

--- a/core/api.py
+++ b/core/api.py
@@ -119,7 +119,7 @@ def get_json(api_endpoint):
 
     if logger.isEnabledFor(logging.DEBUG):
         try:
-            logger.debug("API response text from %s:\n%s" % (url, api_endpoint.text))
+            logger.debug("API response text from %s:\n%s", url, api_endpoint.text)
         except Exception:
             pass
 
@@ -133,7 +133,7 @@ def get_json(api_endpoint):
     else:
         if logger.isEnabledFor(logging.DEBUG):
             try:
-                logger.debug("Decoded JSON from %s:\n%s" % (url, json.dumps(data, indent=2)))
+                logger.debug("Decoded JSON from %s:\n%s", url, json.dumps(data, indent=2))
             except Exception:
                 pass
         return data
@@ -778,9 +778,7 @@ def search_results(api_endpoint, query):
                     data = {"error": getattr(results, "text", "")}
                 if logger.isEnabledFor(logging.DEBUG):
                     try:
-                        logger.debug(
-                            "Parsed error payload: %s" % json.dumps(data)
-                        )
+                        logger.debug("Parsed error payload: %s", json.dumps(data))
                     except Exception:
                         pass
                 logger.error("Search failed: %s - %s", status_code, getattr(results, "reason", ""))

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -22,7 +22,8 @@ def successful(creds, search, args):
     logger.info(msg)
 
     vaultcreds = api.get_json(creds.get_vault_credentials)
-    logger.debug('List Credentials:'+json.dumps(vaultcreds))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug('List Credentials: %s', json.dumps(vaultcreds))
 
     outpost_map = {}
     if getattr(args, "target", None) and hasattr(tideway, "appliance"):
@@ -49,9 +50,10 @@ def successful(creds, search, args):
     data = []
     headers = []
 
-    logger.info('Successful SessionResults:' + json.dumps(credsux_results))
-    logger.info('Successful DeviceInfos:' + json.dumps(devinfosux))
-    logger.info('Failures:' + json.dumps(credfail_results))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug('Successful SessionResults: %s', json.dumps(credsux_results))
+        logger.debug('Successful DeviceInfos: %s', json.dumps(devinfosux))
+        logger.debug('Failures: %s', json.dumps(credfail_results))
 
     suxCreds = tools.session_get(credsux_results)
     suxDev = tools.session_get(devinfosux)


### PR DESCRIPTION
## Summary
- avoid unnecessary JSON serialization in reporting by checking debug level
- parameterize logging and guard JSON dumps in API helper
- ensure debug scripts serialize JSON only when debug logging is enabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891c8f40870832683e1234a7199290b