### PR TITLE
Add timing output for CLI reports

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -4,6 +4,8 @@ import sys
 import logging
 import csv
 import os
+import time
+from functools import wraps
 
 # PIP Modules
 from tabulate import tabulate
@@ -12,6 +14,22 @@ from tabulate import tabulate
 from . import tools, api
 
 logger = logging.getLogger("_output_")
+
+
+def _timer(func):
+    """Decorator to time report generation and log the duration."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = func(*args, **kwargs)
+        elapsed = time.time() - start
+        msg = f"Report completed in {elapsed:.2f} seconds."
+        print(msg)
+        logger.info(msg)
+        return result
+
+    return wrapper
 
 def csv_out(data, heads):
     data.insert(0, heads)
@@ -99,6 +117,7 @@ def fancy_out(data, heads):
     except Exception as e:
         logger.error("Problem printing fancy output:%s\n%s"%(e.__class__,str(e)))
 
+@_timer
 def report(data, heads, args, name=None):
     """Handle generic report output."""
     cli_out = getattr(args, "output_cli", False)
@@ -170,6 +189,7 @@ def query2csv(search, query, filename, appliance):
     else:
         txt_dump("No results.",filename)
 
+@_timer
 def define_txt(args,result,path,filename):
     # Manage all Output options
     cli_out = getattr(args, "output_cli", False)
@@ -192,6 +212,7 @@ def define_txt(args,result,path,filename):
         else:
             txt_dump(result,path)
 
+@_timer
 def define_csv(args,head_ep,data,path,file,target,type):
     # Manage all Output options
     cli_out = getattr(args, "output_cli", False)


### PR DESCRIPTION
## Summary
- add a timing decorator that prints runtime after each report runs
- apply the timer to `report`, `define_txt`, and `define_csv` so CLI reports display duration

## Testing
- `pytest` *(fails: test_get_scans_uses_networks, test_get_scans_caches_ranges)*

------
https://chatgpt.com/codex/tasks/task_e_6891d1e3b3d08326bb60e8e9b0569dd9