### PR TITLE
Limit API debug logs on CLI

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -81,12 +81,20 @@ def get_json(api_endpoint):
         try:
             api_endpoint = api_endpoint()
         except Exception as e:  # pragma: no cover - network errors
-            msg = (
-                "Not able to make api call.\nException: %s\n%s"
-                % (e.__class__, str(e))
-            )
-            print(msg)
-            logger.error(msg)
+            if logger.isEnabledFor(logging.DEBUG):
+                msg = (
+                    "Not able to make api call.\nException: %s\n%s"
+                    % (e.__class__, str(e))
+                )
+                print(msg)
+                logger.error(msg)
+            else:
+                msg = (
+                    "Not able to make api call. Rerun in debug mode for more "
+                    "information."
+                )
+                print(msg)
+                logger.error("Not able to make api call", exc_info=e)
             return {}
 
     if not hasattr(api_endpoint, "status_code"):
@@ -238,9 +246,19 @@ def query(search, args):
         else:
             results = search.search(args.a_query, format="object", limit=500)
     except Exception as e:
-        msg = "Not able to make api call.\nQuery: %s\nException: %s" % (args.a_query, e.__class__)
-        print(msg)
-        logger.error(msg)
+        if logger.isEnabledFor(logging.DEBUG):
+            msg = (
+                "Not able to make api call.\nQuery: %s\nException: %s\n%s"
+                % (args.a_query, e.__class__, str(e))
+            )
+            print(msg)
+            logger.error(msg)
+        else:
+            msg = "Not able to make api call. Rerun in debug mode for more information."
+            print(msg)
+            logger.error(
+                "Not able to make api call for query %s", args.a_query, exc_info=e
+            )
     if len(results) > 0:
         if args.output_csv:
             w = csv.writer(sys.stdout)
@@ -800,9 +818,19 @@ def search_results(api_endpoint, query):
                     pass
             return tools.list_table_to_json(results)
     except Exception as e:
-        msg = "Not able to make api call.\nQuery: %s\nException: %s\n%s" %(query,e.__class__,str(e))
-        print(msg)
-        logger.error(msg)
+        if logger.isEnabledFor(logging.DEBUG):
+            msg = (
+                "Not able to make api call.\nQuery: %s\nException: %s\n%s"
+                % (query, e.__class__, str(e))
+            )
+            print(msg)
+            logger.error(msg)
+        else:
+            msg = "Not able to make api call. Rerun in debug mode for more information."
+            print(msg)
+            logger.error(
+                "Not able to make api call for query %s", query, exc_info=e
+            )
         return []
 
 def hostname(args,dir):

--- a/core/builder.py
+++ b/core/builder.py
@@ -912,7 +912,7 @@ def get_scans(results, list_of_ranges):
                 logger.debug("Scan Range: %s", scan_range)
                 r = scan_range
                 label = result.get('Label')
-                networks = tools.range_to_ips(r)
+                networks = _range_to_networks(r)
                 logger.debug("List of Networks: %s", networks)
                 for ip in list_of_ranges:
                     logger.debug("Checking IP %s in networks", ip)
@@ -928,9 +928,10 @@ def get_scans(results, list_of_ranges):
                                 logger.debug("IP %s added to scheduled_scans", ip)
                                 break
                     else:
-                        if ip in networks:
-                            scan_ranges.append(label)
-                            logger.debug("IP %s added to scheduled_scans", ip)
-                            break
+                        for net in networks:
+                            if isinstance(net, (ipaddress.IPv4Network, ipaddress.IPv6Network)) and ip in net:
+                                scan_ranges.append(label)
+                                logger.debug("IP %s added to scheduled_scans", ip)
+                                break
     scan_ranges = tools.sortlist(scan_ranges)
     return scan_ranges


### PR DESCRIPTION
## Summary
- avoid printing verbose API errors unless debug logging is enabled
- cache and reuse scan range network parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891fdf9e40c8326a4b6fd6a803ec173