### PR TITLE
Fix header handling in discovery_runs CSV output

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -347,10 +347,18 @@ def discovery_runs(disco, args, dir):
         runs = json.loads(json.dumps(r))
         logger.debug('Runs:\n%s' % r)
         header, rows = tools.json2csv(runs)
-        header.insert(0,"Discovery Instance")
+        header.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
-        output.define_csv(args,None,rows,dir+defaults.current_scans_filename,args.output_file,args.target,"csv_file")
+        output.define_csv(
+            args,
+            header,
+            rows,
+            dir + defaults.current_scans_filename,
+            args.output_file,
+            args.target,
+            "csv_file",
+        )
 
 def show_runs(disco, args):
     logger.debug("Calling disco.get_discovery_runs")


### PR DESCRIPTION
## Summary
- Pass computed header from `tools.json2csv` to `output.define_csv` for discovery run exports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922763b2ac8326a61890049bfbcfc9