### PR TITLE
Refine show_runs output handling

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -383,21 +383,41 @@ def show_runs(disco, args):
             value = run.get(header)
             run_csv.append(value)
         run_csvs.append(run_csv)
-    run_csvs.insert(0, headers)
+
     export = getattr(args, "export", False)
     outfile = getattr(args, "file", getattr(args, "output_file", None))
     if export:
         w = csv.writer(sys.stdout)
+        w.writerow(headers)
         w.writerows(run_csvs)
     elif outfile:
         with open(outfile, "w", newline="") as file:
             writer = csv.writer(file)
+            writer.writerow(headers)
             writer.writerows(run_csvs)
             msg = "Results written to %s" % outfile
             print(msg)
             logger.info(msg)
     else:
-        pprint(runs)
+        if getattr(args, "excavate", None):
+            out_dir = getattr(args, "reporting_dir", "")
+            output.define_csv(
+                args,
+                headers,
+                run_csvs,
+                os.path.join(out_dir, defaults.current_scans_filename),
+                getattr(args, "output_file", None),
+                getattr(args, "target", None),
+                "csv_file",
+            )
+        elif getattr(args, "debugging", False):
+            pprint(runs)
+        else:
+            print(f"Active discovery runs: {len(runs)}")
+            for r in runs:
+                rid = r.get("run_id") or r.get("id") or r.get("label") or "N/A"
+                status = r.get("status", "unknown")
+                print(f" - {rid}: {status}")
 
 def sensitive(search, args, dir):
     output.define_csv(args,search,queries.sensitive_data,dir+defaults.sensitive_data_filename,args.output_file,args.target,"query")


### PR DESCRIPTION
## Summary
- Summarize active discovery runs instead of dumping raw JSON
- Export run details through `output.define_csv` during excavation
- Print full JSON output only when debug flag is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892274fa6dc8326a62caee453568496