### PR TITLE
feat: add timing for report generation

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -146,6 +146,7 @@ def get_json(api_endpoint):
                 pass
         return data
 
+@output._timer
 def admin(disco,args,dir):
     logger.debug("Calling disco.admin() with no parameters")
     data = disco.admin()
@@ -161,9 +162,11 @@ def admin(disco,args,dir):
     logger.info('Discovery Version:\n%s'%os_version)
     output.define_txt(args,json.dumps(result['versions']),dir+defaults.api_filename,None)
 
+@output._timer
 def audit(search,args,dir):
     output.define_csv(args,search,queries.audit,dir+defaults.audit_filename,args.output_file,args.target,"query")
 
+@output._timer
 def baseline(disco, args, dir):
     logger.debug("Calling disco.baseline() with no parameters")
     data = disco.baseline()
@@ -201,12 +204,15 @@ def baseline(disco, args, dir):
         last_message = bl
         output.txt_dump(last_message,dir+"/baseline_status.txt")
 
+@output._timer
 def cmdb_config(search, args, dir):
     output.define_csv(args,search,queries.cmdb_sync_config,dir+defaults.cmdbsync_filename,args.output_file,args.target,"query")
 
+@output._timer
 def modules(search, args, dir):
     output.define_csv(args,search,queries.patterns,dir+defaults.tw_knowledge_filename,args.output_file,args.target,"query")
 
+@output._timer
 def licensing(disco, args, dir):
     try:
         # CSV
@@ -237,6 +243,7 @@ def licensing(disco, args, dir):
             if chunk:  # filter out keep-alive new chunks
                 handle.write(chunk)
 
+@output._timer
 def query(search, args):
     """Run an ad-hoc query against the search endpoint."""
     results = []
@@ -318,6 +325,7 @@ def map_outpost_credentials(appliance):
             logger.error("Error processing outpost %s: %s", url, e)
     return mapping
 
+@output._timer
 def success(twcreds, twsearch, args, dir):
     reporting.successful(twcreds, twsearch, args)
     #if args.output_file:
@@ -326,12 +334,15 @@ def success(twcreds, twsearch, args, dir):
     #    df.to_csv(dir+defaults.success_filename, index=False)
     #    os.remove(args.output_file)
 
+@output._timer
 def schedules(search, args, dir):
     output.define_csv(args,search,queries.scan_ranges,dir+defaults.scan_ranges_filename,args.output_file,args.target,"query")
 
+@output._timer
 def excludes(search, args, dir):
     output.define_csv(args,search,queries.exclude_ranges,dir+defaults.exclude_ranges_filename,args.output_file,args.target,"query")
 
+@output._timer
 def discovery_runs(disco, args, dir):
     logger.info("Checking Scan ranges...")
     logger.debug("Calling disco.get_discovery_runs")
@@ -352,6 +363,7 @@ def discovery_runs(disco, args, dir):
             row.insert(0, args.target)
         output.define_csv(args,None,rows,dir+defaults.current_scans_filename,args.output_file,args.target,"csv_file")
 
+@output._timer
 def show_runs(disco, args):
     logger.debug("Calling disco.get_discovery_runs")
     api_response = disco.get_discovery_runs
@@ -399,24 +411,31 @@ def show_runs(disco, args):
     else:
         pprint(runs)
 
+@output._timer
 def sensitive(search, args, dir):
     output.define_csv(args,search,queries.sensitive_data,dir+defaults.sensitive_data_filename,args.output_file,args.target,"query")
 
+@output._timer
 def tpl_export(search, args, dir):
     reporting.tpl_export(search, queries.tpl_export, dir, "api", None, None, None)
 
+@output._timer
 def eca_errors(search, args, dir):
     output.define_csv(args,search,queries.eca_error,dir+defaults.eca_errors_filename,args.output_file,args.target,"query")
 
+@output._timer
 def open_ports(search, args, dir):
     output.define_csv(args,search,queries.open_ports,dir+defaults.open_ports_filename,args.output_file,args.target,"query")
 
+@output._timer
 def host_util(search, args, dir):
     output.define_csv(args,search,queries.host_utilisation,dir+defaults.host_util_filename,args.output_file,args.target,"query")
 
+@output._timer
 def orphan_vms(search, args, dir):
     output.define_csv(args,search,queries.orphan_vms,dir+defaults.orphan_vms_filename,args.output_file,args.target,"query")
 
+@output._timer
 def missing_vms(search, args, dir):
     if getattr(args, "resolve_hostnames", False):
         response = search_results(search, queries.missing_vms)
@@ -489,27 +508,35 @@ def missing_vms(search, args, dir):
             "query",
         )
 
+@output._timer
 def near_removal(search, args, dir):
     output.define_csv(args,search,queries.near_removal,dir+defaults.near_removal_filename,args.output_file,args.target,"query")
 
+@output._timer
 def removed(search, args, dir):
     output.define_csv(args,search,queries.removed,dir+defaults.removed_filename,args.output_file,args.target,"query")
 
+@output._timer
 def oslc(search, args, dir):
     output.define_csv(args,search,queries.os_lifecycle,dir+defaults.os_lifecycle_filename,args.output_file,args.target,"query")
 
+@output._timer
 def slc(search, args, dir):
     output.define_csv(args,search,queries.software_lifecycle,dir+defaults.si_lifecycle_filename,args.output_file,args.target,"query")
 
+@output._timer
 def dblc(search, args, dir):
     output.define_csv(args,search,queries.db_lifecycle,dir+defaults.db_lifecycle_filename,args.output_file,args.target,"query")
 
+@output._timer
 def snmp(search, args, dir):
     output.define_csv(args,search,queries.snmp_devices,dir+defaults.snmp_unrecognised_filename,args.output_file,args.target,"query")
 
+@output._timer
 def agents(search, args, dir):
     output.define_csv(args,search,queries.agents,dir+defaults.installed_agents_filename,args.output_file,args.target,"query")
 
+@output._timer
 def software_users(search, args, dir):
     output.define_csv(args,search,queries.user_accounts,dir+defaults.si_user_accounts_filename,args.output_file,args.target,"query")
 
@@ -527,6 +554,7 @@ def devices_lookup(search):
             }
     return mapping
 
+@output._timer
 def tku(knowledge, args, dir):
     logger.info("Checking Knowledge...")
     logger.debug("Calling knowledge.get_knowledge")
@@ -656,6 +684,7 @@ def update_schedule_timezone(disco, args):
             getattr(resp, "text", "N/A"),
         )
 
+@output._timer
 def vault(vault, args, dir):
     logger.info("Checking Vault...")
     logger.debug("Calling vault.get_vault")
@@ -833,5 +862,6 @@ def search_results(api_endpoint, query):
             )
         return []
 
+@output._timer
 def hostname(args,dir):
     output.define_txt(args,args.target,dir+defaults.hostname_filename,None)

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -18,6 +18,7 @@ import tideway
 
 logger = logging.getLogger("_reporting_")
 
+@output._timer
 def successful(creds, search, args):
     msg = "Running: Success Report )"
     logger.info(msg)
@@ -311,6 +312,7 @@ def successful(creds, search, args):
         print(msg)
     output.report(data, headers, args, name="credential_success")
 
+@output._timer
 def successful_cli(client, args, sysuser, passwd, reporting_dir):
     credentials = access.remote_cmd('tw_vault_control --show --json -u %s -p %s'%(sysuser,passwd),client)
     credjson = []
@@ -391,6 +393,7 @@ def successful_cli(client, args, sysuser, passwd, reporting_dir):
         row.insert(0, args.target)
     output.csv_file(data, headers, reporting_dir+"/credentials.csv")
 
+@output._timer
 def devices(twsearch, twcreds, args):
 
     print("\nDevice Access Analyis")
@@ -692,6 +695,7 @@ def devices(twsearch, twcreds, args):
         print(msg)
     output.report(data, headers, args, name="devices")
 
+@output._timer
 def ipaddr(search, credentials, args):
     ipaddr = args.excavate[1]
     msg = "\nIP Address Lookup: %s" % ipaddr
@@ -1073,6 +1077,7 @@ def _gather_discovery_data(twsearch, twcreds):
     return disco_data
 
 
+@output._timer
 def discovery_access(twsearch, twcreds, args):
     print("\nDiscovery Access Export")
     print("-----------------------")
@@ -1188,6 +1193,7 @@ def discovery_access(twsearch, twcreds, args):
     output.report(data, headers, args, name="discovery_access")
 
 
+@output._timer
 def discovery_analysis(twsearch, twcreds, args):
     print("\nDiscovery Access Analysis")
     print("-------------------------")
@@ -1318,6 +1324,7 @@ def discovery_analysis(twsearch, twcreds, args):
     output.report(data, headers, args, name="discovery_analysis")
 
 
+@output._timer
 def tpl_export(search, query, dir, method, client, sysuser, syspass):
     tpldir = dir + "/tpl"
     if not os.path.exists(tpldir):


### PR DESCRIPTION
## Summary
- time core reporting functions with reusable decorator
- time API report helpers to capture full generation cost

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922769d2548326b771a856aae00cf6