### PR TITLE
refactor: time only top-level reports

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -146,7 +146,6 @@ def get_json(api_endpoint):
                 pass
         return data
 
-@output._timer
 def admin(disco,args,dir):
     logger.debug("Calling disco.admin() with no parameters")
     data = disco.admin()
@@ -162,11 +161,9 @@ def admin(disco,args,dir):
     logger.info('Discovery Version:\n%s'%os_version)
     output.define_txt(args,json.dumps(result['versions']),dir+defaults.api_filename,None)
 
-@output._timer
 def audit(search,args,dir):
     output.define_csv(args,search,queries.audit,dir+defaults.audit_filename,args.output_file,args.target,"query")
 
-@output._timer
 def baseline(disco, args, dir):
     logger.debug("Calling disco.baseline() with no parameters")
     data = disco.baseline()
@@ -204,15 +201,12 @@ def baseline(disco, args, dir):
         last_message = bl
         output.txt_dump(last_message,dir+"/baseline_status.txt")
 
-@output._timer
 def cmdb_config(search, args, dir):
     output.define_csv(args,search,queries.cmdb_sync_config,dir+defaults.cmdbsync_filename,args.output_file,args.target,"query")
 
-@output._timer
 def modules(search, args, dir):
     output.define_csv(args,search,queries.patterns,dir+defaults.tw_knowledge_filename,args.output_file,args.target,"query")
 
-@output._timer
 def licensing(disco, args, dir):
     try:
         # CSV
@@ -243,7 +237,6 @@ def licensing(disco, args, dir):
             if chunk:  # filter out keep-alive new chunks
                 handle.write(chunk)
 
-@output._timer
 def query(search, args):
     """Run an ad-hoc query against the search endpoint."""
     results = []
@@ -325,7 +318,6 @@ def map_outpost_credentials(appliance):
             logger.error("Error processing outpost %s: %s", url, e)
     return mapping
 
-@output._timer
 def success(twcreds, twsearch, args, dir):
     reporting.successful(twcreds, twsearch, args)
     #if args.output_file:
@@ -334,15 +326,12 @@ def success(twcreds, twsearch, args, dir):
     #    df.to_csv(dir+defaults.success_filename, index=False)
     #    os.remove(args.output_file)
 
-@output._timer
 def schedules(search, args, dir):
     output.define_csv(args,search,queries.scan_ranges,dir+defaults.scan_ranges_filename,args.output_file,args.target,"query")
 
-@output._timer
 def excludes(search, args, dir):
     output.define_csv(args,search,queries.exclude_ranges,dir+defaults.exclude_ranges_filename,args.output_file,args.target,"query")
 
-@output._timer
 def discovery_runs(disco, args, dir):
     logger.info("Checking Scan ranges...")
     logger.debug("Calling disco.get_discovery_runs")
@@ -371,7 +360,6 @@ def discovery_runs(disco, args, dir):
             "csv_file",
         )
 
-@output._timer
 def show_runs(disco, args):
     logger.debug("Calling disco.get_discovery_runs")
     api_response = disco.get_discovery_runs
@@ -439,7 +427,6 @@ def show_runs(disco, args):
                 status = r.get("status", "unknown")
                 print(f" - {rid}: {status}")
 
-@output._timer
 def sensitive(search, args, dir):
     results = search_results(search, queries.sensitive_data)
     count = len(results) if isinstance(results, list) else 0
@@ -463,11 +450,9 @@ def sensitive(search, args, dir):
         "csv_file",
     )
 
-@output._timer
 def tpl_export(search, args, dir):
     reporting.tpl_export(search, queries.tpl_export, dir, "api", None, None, None)
 
-@output._timer
 def eca_errors(search, args, dir):
     results = search_results(search, queries.eca_error)
     count = len(results) if isinstance(results, list) else 0
@@ -491,7 +476,6 @@ def eca_errors(search, args, dir):
         "csv_file",
     )
 
-@output._timer
 def open_ports(search, args, dir):
     results = search_results(search, queries.open_ports)
     count = len(results) if isinstance(results, list) else 0
@@ -515,7 +499,6 @@ def open_ports(search, args, dir):
         "csv_file",
     )
 
-@output._timer
 def host_util(search, args, dir):
     results = search_results(search, queries.host_utilisation)
     count = len(results) if isinstance(results, list) else 0
@@ -539,11 +522,9 @@ def host_util(search, args, dir):
         "csv_file",
     )
 
-@output._timer
 def orphan_vms(search, args, dir):
     output.define_csv(args,search,queries.orphan_vms,dir+defaults.orphan_vms_filename,args.output_file,args.target,"query")
 
-@output._timer
 def missing_vms(search, args, dir):
     if getattr(args, "resolve_hostnames", False):
         response = search_results(search, queries.missing_vms)
@@ -616,35 +597,27 @@ def missing_vms(search, args, dir):
             "query",
         )
 
-@output._timer
 def near_removal(search, args, dir):
     output.define_csv(args,search,queries.near_removal,dir+defaults.near_removal_filename,args.output_file,args.target,"query")
 
-@output._timer
 def removed(search, args, dir):
     output.define_csv(args,search,queries.removed,dir+defaults.removed_filename,args.output_file,args.target,"query")
 
-@output._timer
 def oslc(search, args, dir):
     output.define_csv(args,search,queries.os_lifecycle,dir+defaults.os_lifecycle_filename,args.output_file,args.target,"query")
 
-@output._timer
 def slc(search, args, dir):
     output.define_csv(args,search,queries.software_lifecycle,dir+defaults.si_lifecycle_filename,args.output_file,args.target,"query")
 
-@output._timer
 def dblc(search, args, dir):
     output.define_csv(args,search,queries.db_lifecycle,dir+defaults.db_lifecycle_filename,args.output_file,args.target,"query")
 
-@output._timer
 def snmp(search, args, dir):
     output.define_csv(args,search,queries.snmp_devices,dir+defaults.snmp_unrecognised_filename,args.output_file,args.target,"query")
 
-@output._timer
 def agents(search, args, dir):
     output.define_csv(args,search,queries.agents,dir+defaults.installed_agents_filename,args.output_file,args.target,"query")
 
-@output._timer
 def software_users(search, args, dir):
     output.define_csv(args,search,queries.user_accounts,dir+defaults.si_user_accounts_filename,args.output_file,args.target,"query")
 
@@ -662,7 +635,6 @@ def devices_lookup(search):
             }
     return mapping
 
-@output._timer
 def tku(knowledge, args, dir):
     logger.info("Checking Knowledge...")
     logger.debug("Calling knowledge.get_knowledge")
@@ -792,7 +764,6 @@ def update_schedule_timezone(disco, args):
             getattr(resp, "text", "N/A"),
         )
 
-@output._timer
 def vault(vault, args, dir):
     logger.info("Checking Vault...")
     logger.debug("Calling vault.get_vault")
@@ -970,6 +941,5 @@ def search_results(api_endpoint, query):
             )
         return []
 
-@output._timer
 def hostname(args,dir):
     output.define_txt(args,args.target,dir+defaults.hostname_filename,None)

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -18,7 +18,7 @@ import tideway
 
 logger = logging.getLogger("_reporting_")
 
-@output._timer
+@output._timer("Success Report")
 def successful(creds, search, args):
     msg = "Running: Success Report )"
     logger.info(msg)
@@ -312,7 +312,7 @@ def successful(creds, search, args):
         print(msg)
     output.report(data, headers, args, name="credential_success")
 
-@output._timer
+@output._timer("Success Report (CLI)")
 def successful_cli(client, args, sysuser, passwd, reporting_dir):
     credentials = access.remote_cmd('tw_vault_control --show --json -u %s -p %s'%(sysuser,passwd),client)
     credjson = []
@@ -393,7 +393,7 @@ def successful_cli(client, args, sysuser, passwd, reporting_dir):
         row.insert(0, args.target)
     output.csv_file(data, headers, reporting_dir+"/credentials.csv")
 
-@output._timer
+@output._timer("Device Access Analysis")
 def devices(twsearch, twcreds, args):
 
     print("\nDevice Access Analyis")
@@ -695,7 +695,7 @@ def devices(twsearch, twcreds, args):
         print(msg)
     output.report(data, headers, args, name="devices")
 
-@output._timer
+@output._timer("IP Address Lookup")
 def ipaddr(search, credentials, args):
     ipaddr = args.excavate[1]
     msg = "\nIP Address Lookup: %s" % ipaddr
@@ -1077,7 +1077,7 @@ def _gather_discovery_data(twsearch, twcreds):
     return disco_data
 
 
-@output._timer
+@output._timer("Discovery Access Export")
 def discovery_access(twsearch, twcreds, args):
     print("\nDiscovery Access Export")
     print("-----------------------")
@@ -1193,7 +1193,7 @@ def discovery_access(twsearch, twcreds, args):
     output.report(data, headers, args, name="discovery_access")
 
 
-@output._timer
+@output._timer("Discovery Access Analysis")
 def discovery_analysis(twsearch, twcreds, args):
     print("\nDiscovery Access Analysis")
     print("-------------------------")
@@ -1324,7 +1324,7 @@ def discovery_analysis(twsearch, twcreds, args):
     output.report(data, headers, args, name="discovery_analysis")
 
 
-@output._timer
+@output._timer("TPL Export")
 def tpl_export(search, query, dir, method, client, sysuser, syspass):
     tpldir = dir + "/tpl"
     if not os.path.exists(tpldir):


### PR DESCRIPTION
## Summary
- make output._timer accept a friendly name
- remove timer usage from helper API/output functions
- apply friendly timer to high level report functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926328b8cc8326a187f9399ecf3beb