### PR TITLE
Use consistent report save wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python3 dismal.py --access_method cli \
 
 The options `-P`, `-T` and `-W` can be used to read the UI password, API token and tideway password from files instead of providing them inline.
 
-By default, reports are written to an `output_<appliance>` directory in the current working directory.
+By default, reports are saved to an `output_<appliance>` directory in the current working directory.
 Use the `--stdout` option to suppress file output and print results directly to the terminal.
 
 ## Reports

--- a/core/api.py
+++ b/core/api.py
@@ -274,7 +274,7 @@ def query(search, args):
             with open(args.output_file, 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerows(results)
-                msg = "Results written to %s" % args.output_file
+                msg = "Report saved to %s" % args.output_file
                 print(msg)
                 logger.info(msg)
         else:
@@ -415,7 +415,7 @@ def show_runs(disco, args):
             writer = csv.writer(file)
             writer.writerow(headers)
             writer.writerows(run_csvs)
-            msg = "Results written to %s" % outfile
+            msg = "Report saved to %s" % outfile
             print(msg)
             logger.info(msg)
     else:

--- a/core/output.py
+++ b/core/output.py
@@ -70,7 +70,7 @@ def csv_file(data, heads, filename):
         try:
             writer = csv.writer(file, delimiter=",")
             writer.writerows(data)
-            msg = "Results written to %s" % filename
+            msg = "Report saved to %s" % filename
             print(msg)
             logger.info(msg)
         except Exception as e:


### PR DESCRIPTION
## Summary
- Update CSV output message to "Report saved" wording
- Align API save messages with new phrasing
- Clarify README about report save location

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892632a14ac83268ee207ceff1aa655