### PR TITLE
feat: allow naming timer decorator via positional arg

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -20,9 +20,15 @@ def _timer(func=None, *, name=None):
 
     Parameters
     ----------
+    func : callable or str, optional
+        Function to decorate or a friendly name for the report.
     name : str, optional
         Friendly name for the report being executed.
     """
+
+    if func is not None and not callable(func):
+        name = func
+        func = None
 
     def decorator(func):
         @wraps(func)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("core.api", types.SimpleNamespace())
+sys.modules.setdefault("core.tools", types.SimpleNamespace())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.output as output
+
+@output._timer
+def decorated_plain():
+    return "ok"
+
+@output._timer()
+def decorated_called():
+    return "ok"
+
+@output._timer("Report Name")
+def decorated_positional():
+    return "ok"
+
+@output._timer(name="Report Name")
+def decorated_keyword():
+    return "ok"
+
+
+def test_timer_variants(capsys, monkeypatch):
+    def run(func, expected_name):
+        times = [0, 1]
+        monkeypatch.setattr(output.time, "time", lambda: times.pop(0))
+        assert func() == "ok"
+        out = capsys.readouterr().out
+        assert f"Running report {expected_name}..." in out
+        assert "Report completed in 1.00 seconds" in out
+
+    run(decorated_plain, "decorated_plain")
+    run(decorated_called, "decorated_called")
+    run(decorated_positional, "Report Name")
+    run(decorated_keyword, "Report Name")


### PR DESCRIPTION
## Summary
- allow `_timer` to accept a positional name string
- add tests for all `_timer` decorator invocation forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926b68437883269fcac6776a01e981