### PR TITLE
Rename Source_Dir column to Exported_Logs

### DIFF
--- a/merge_outputs.py
+++ b/merge_outputs.py
@@ -25,7 +25,7 @@ for csv_name in unique_csv_filenames:
     for file in matching_files:
         try:
             df = pd.read_csv(file)
-            df['Source_Dir'] = os.path.basename(os.path.dirname(file))  # optional: add source dir
+            df['Exported_Logs'] = os.path.basename(os.path.dirname(file))  # record export directory
             dfs.append(df)
         except Exception as e:
             print(f"Error reading {file}: {e}")
@@ -33,7 +33,7 @@ for csv_name in unique_csv_filenames:
     if dfs:
         combined = pd.concat(dfs, ignore_index=True)
         sheet_name = os.path.splitext(csv_name)[0][:31]  # Excel sheet name limit
-        combined.to_excel(writer, sheet_name=sheet_name, index=False)
+        combined.to_excel(writer, sheet_name=sheet_name, index=False, header=True)
         print(f"Added sheet: {sheet_name} ({len(dfs)} files)")
     else:
         print(f"No data found for {csv_name}")


### PR DESCRIPTION
## Summary
- Record the originating output directory under an `Exported_Logs` column when merging CSVs.
- Explicitly retain column headers when writing sheets so `Exported_Logs` appears in each tab.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893391165a88326be16b7816738a4fa