### PR TITLE
Ping outpost before mapping credentials

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -303,6 +303,12 @@ def map_outpost_credentials(appliance):
         if not url:
             continue
         parsed = urlparse(url)
+        host = parsed.hostname or (parsed.netloc or parsed.path).split(":")[0]
+        if access.ping(host) != 0:
+            msg = f"Outpost {url} is not available"
+            print(msg)
+            logger.warning(msg)
+            continue
         target = (parsed.netloc or parsed.path).rstrip("/")
         try:
             op_app = tideway.outpost(target, token, api_version=api_version)


### PR DESCRIPTION
## Summary
- Verify outpost availability by pinging each hostname before retrieving credentials
- Warn and skip unreachable outposts
- Test outpost credential mapping with unreachable outposts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893393cc33883269834c9fbbc786649