### PR TITLE
Handle plain string search queries

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -863,6 +863,8 @@ def update_cred(appliance, uuid):
 
 def search_results(api_endpoint, query):
     try:
+        if isinstance(query, str):
+            query = {"query": query}
         if isinstance(query, dict) and isinstance(query.get("query"), str):
             query = dict(query)
             query["query"] = query["query"].replace("\n", " ").replace("\r", " ")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,6 +240,26 @@ def test_search_results_sanitizes_once(monkeypatch):
     assert CountingStr.calls == 2
 
 
+def test_search_results_wraps_str_query(monkeypatch):
+    """Ensure plain string queries are wrapped and sanitized."""
+
+    captured = {}
+
+    class Recorder:
+        def search(self, query, format="object", limit=500):
+            captured["query"] = query
+            return DummyResponse(200, "[]")
+
+    qry = "search Device\nwhere name = 'foo'\r"
+    search_results(Recorder(), qry)
+
+    sent = captured["query"]
+    assert isinstance(sent, dict)
+    assert "query" in sent
+    assert "\n" not in sent["query"]
+    assert "\r" not in sent["query"]
+
+
 def test_search_results_returns_error_payload(caplog):
     resp = DummyResponse(400, '{"msg": "bad"}', reason="Bad")
     search = DummySearch(resp)


### PR DESCRIPTION
## Summary
- Wrap string inputs in `search_results` into `{"query": query}` before sanitization
- Add unit test ensuring string queries are wrapped and sanitized

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893394649188326b385d49671340154