### PR TITLE
Ensure info logs are printed

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -491,6 +491,7 @@ def scheduling(vault, search, args):
     print("\nScheduled Runs with Credentials")
     print("-------------------------------")
     logger.info("Running Schedules Report...")
+    print("Running Schedules Report...")
     msg = None
 
     heads = ["Name", "Type", "Range ID", "Ranges", "Scan Level", "When", "Credentials"]
@@ -528,8 +529,8 @@ def scheduling(vault, search, args):
         return
     if len(excludes) == 0:
         msg = "No exclude ranges found"
-        print(msg)
         logger.info(msg)
+        print(msg)
         results = {"results": []}
     else:
         results = excludes[0]
@@ -591,8 +592,8 @@ def scheduling(vault, search, args):
         return
     if len(scan_ranges) == 0:
         msg = "No scan ranges found"
-        print(msg)
         logger.info(msg)
+        print(msg)
         results = {"results": []}
     else:
         first = scan_ranges[0]
@@ -656,6 +657,7 @@ def scheduling(vault, search, args):
 def unique_identities(search):
 
     logger.info("Running: Unique Identities report...")
+    print("Running: Unique Identities report...")
 
     devices = api.search_results(search, queries.deviceInfo)
     da_results = api.search_results(search, queries.da_ip_lookup)
@@ -773,6 +775,7 @@ def overlapping(tw_search, args):
     print("\nScheduled Scans Overlapping")
     print("---------------------------")
     logger.info("Running: Overlapping Report...")
+    print("Running: Overlapping Report...")
     heads = ["IP Address", "Scan Schedules"]
 
     logger.debug("Executing scan range query: %s", queries.scanrange.get("query", queries.scanrange))
@@ -786,8 +789,8 @@ def overlapping(tw_search, args):
         return
     if len(scan_ranges) == 0:
         msg = "No scan ranges found"
-        print(msg)
         logger.info(msg)
+        print(msg)
         results = {"results": []}
     else:
         first = scan_ranges[0]
@@ -835,8 +838,8 @@ def overlapping(tw_search, args):
         return
     if len(excludes) == 0:
         msg = "No exclude ranges found"
-        print(msg)
         logger.info(msg)
+        print(msg)
         e = {"results": []}
     else:
         e = excludes[0]

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -399,6 +399,7 @@ def devices(twsearch, twcreds, args):
     print("\nDevice Access Analyis")
     print("---------------------")
     logger.info("Running Data Analysis Report...")
+    print("Running Data Analysis Report...")
 
     vaultcreds = api.get_json(twcreds.get_vault_credentials)
 
@@ -1198,6 +1199,7 @@ def discovery_analysis(twsearch, twcreds, args):
     print("\nDiscovery Access Analysis")
     print("-------------------------")
     logger.info("Running DA Analysis Report")
+    print("Running DA Analysis Report")
 
     disco_data = _gather_discovery_data(twsearch, twcreds)
 


### PR DESCRIPTION
## Summary
- Print unique identity report startup messages
- Echo scheduling and overlapping report info logs to console
- Show Data Analysis and Discovery Access Analysis report start messages on stdout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893394f1fa883268548101a7929a10c