### PR TITLE
Reuse discovery data for access reports

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1087,12 +1087,16 @@ def _gather_discovery_data(twsearch, twcreds, args):
 
 
 @output._timer("Discovery Access Export")
-def discovery_access(twsearch, twcreds, args):
+def discovery_access(twsearch, twcreds, args, disco_data=None):
     print("\nDiscovery Access Export")
     print("-----------------------")
     logger.info("Running DA Report")
 
-    disco_data = _gather_discovery_data(twsearch, twcreds, args)
+    # Allow pre-fetched data to be supplied for efficiency; fall back to
+    # gathering it locally if not provided. This keeps standalone usage
+    # unchanged while enabling reuse of the same data for multiple reports.
+    if disco_data is None:
+        disco_data = _gather_discovery_data(twsearch, twcreds, args)
 
     msg = os.linesep
     data = []
@@ -1203,13 +1207,16 @@ def discovery_access(twsearch, twcreds, args):
 
 
 @output._timer("Discovery Access Analysis")
-def discovery_analysis(twsearch, twcreds, args):
+def discovery_analysis(twsearch, twcreds, args, disco_data=None):
     print("\nDiscovery Access Analysis")
     print("-------------------------")
     logger.info("Running DA Analysis Report")
     print("Running DA Analysis Report")
 
-    disco_data = _gather_discovery_data(twsearch, twcreds, args)
+    # Reuse provided discovery data if available; otherwise gather it
+    # independently so the function can be executed stand-alone.
+    if disco_data is None:
+        disco_data = _gather_discovery_data(twsearch, twcreds, args)
 
     for record in disco_data:
         current = record.get("end_state")

--- a/dismal.py
+++ b/dismal.py
@@ -636,11 +636,18 @@ if args.access_method=="api":
     if excavate_default or (args.excavate and args.excavate[0] == "overlapping_ips"):
         builder.overlapping(search, args)
 
+    # Gather discovery data once and reuse for both reporting calls.
+    disco_data = None
+    if excavate_default or (
+        args.excavate and args.excavate[0] in ("discovery_access", "discovery_analysis")
+    ):
+        disco_data = reporting._gather_discovery_data(search, creds, args)
+
     if excavate_default or (args.excavate and args.excavate[0] == "discovery_access"):
-        reporting.discovery_access(search, creds, args)
+        reporting.discovery_access(search, creds, args, disco_data)
 
     if excavate_default or (args.excavate and args.excavate[0] == "discovery_analysis"):
-        reporting.discovery_analysis(search, creds, args)
+        reporting.discovery_analysis(search, creds, args, disco_data)
 
     if excavate_default or (args.excavate and args.excavate[0] == "active_runs"):
         api.show_runs(disco, args)


### PR DESCRIPTION
## Summary
- allow `discovery_access` and `discovery_analysis` to accept optional pre-fetched discovery data
- gather discovery data once in `dismal.py` and pass to both reports

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c566db41483269ffe518b93d21a62