### PR TITLE
Add reusable duration formatter and test coverage

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -15,6 +15,27 @@ from . import tools, api
 
 logger = logging.getLogger("_output_")
 
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds into a human-friendly string.
+
+    Parameters
+    ----------
+    seconds : float
+        The number of seconds to format.
+
+    Returns
+    -------
+    str
+        A string representing the duration in seconds, minutes, or hours
+        depending on the magnitude.
+    """
+
+    if seconds < 60:
+        return f"{seconds:.2f} seconds"
+    if seconds < 3600:
+        return f"{seconds / 60:.2f} minutes"
+    return f"{seconds / 3600:.2f} hours"
+
 def _timer(func=None, *, name=None):
     """Decorator to time report generation and log the duration.
 
@@ -40,12 +61,7 @@ def _timer(func=None, *, name=None):
             start = time.time()
             result = func(*args, **kwargs)
             elapsed = time.time() - start
-            if elapsed < 60:
-                formatted = f"{elapsed:.2f} seconds"
-            elif elapsed < 3600:
-                formatted = f"{elapsed/60:.2f} minutes"
-            else:
-                formatted = f"{elapsed/3600:.2f} hours"
+            formatted = format_duration(elapsed)
             msg = f"Report completed in {formatted}"
             print(msg)
             logger.info(msg)

--- a/dismal.py
+++ b/dismal.py
@@ -718,7 +718,8 @@ if cli_target:
     cli_target.close()
 
 elapsed = time.time() - start_time
-msg = f"Completed in {elapsed:.2f} seconds"
+formatted = output.format_duration(elapsed)
+msg = f"Completed in {formatted}"
 print(msg)
 logger.info(msg)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -40,3 +40,9 @@ def test_timer_variants(capsys, monkeypatch):
     run(decorated_called, "decorated_called")
     run(decorated_positional, "Report Name")
     run(decorated_keyword, "Report Name")
+
+
+def test_format_duration_units():
+    assert output.format_duration(45) == "45.00 seconds"
+    assert output.format_duration(120) == "2.00 minutes"
+    assert output.format_duration(7200) == "2.00 hours"


### PR DESCRIPTION
## Summary
- Add `format_duration` helper to convert seconds into readable units
- Use `format_duration` in `_timer` and CLI completion message
- Test duration formatting for seconds, minutes, and hours

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689daaae200c8326b2ca5dbca12b48f8