### PR TITLE
feat: extend host utilisation report

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -517,8 +517,24 @@ def host_util(search, args, dir):
     if isinstance(results, list) and results:
         header, rows = tools.json2csv(results)
         header.insert(0, "Discovery Instance")
+        numeric_fields = [
+            "Candidate Software Instances",
+            "Running Processes",
+            "Running Services (Windows)",
+            "Running Software Instances",
+        ]
+        numeric_indexes = [
+            header.index(field)
+            for field in numeric_fields
+            if field in header
+        ]
         for row in rows:
             row.insert(0, args.target)
+            for idx in numeric_indexes:
+                try:
+                    row[idx] = int(row[idx])
+                except (ValueError, TypeError):
+                    row[idx] = 0
     else:
         header.insert(0, "Discovery Instance")
     output.define_csv(

--- a/core/queries.py
+++ b/core/queries.py
@@ -279,6 +279,7 @@ host_utilisation = """
                         hostname,
                         hash(hostname) as 'hashed_hostname',
                         os,
+                        os_type as 'OS_Type',
                         virtual,
                         cloud,
                         #InferredElement:Inference:Associate:DiscoveryAccess.endpoint as 'Endpoint',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -372,3 +372,48 @@ def test_update_schedule_timezone_reset():
 
     assert disco.patches[0][1]["schedule"]["start_times"] == [15]
 
+
+def test_host_util_converts_numeric_columns(monkeypatch):
+    sample = [
+        {
+            "hostname": "h1",
+            "hashed_hostname": "hash",
+            "os": "Linux",
+            "OS_Type": "Linux",
+            "virtual": False,
+            "cloud": False,
+            "Endpoint": "ep",
+            "Running Software Instances": "1",
+            "Candidate Software Instances": "2",
+            "Running Processes": "3",
+            "Running Services (Windows)": "4",
+        }
+    ]
+
+    monkeypatch.setattr(api_mod, "search_results", lambda *a, **k: sample)
+    monkeypatch.setattr(api_mod.tools, "completage", lambda *a, **k: 0)
+
+    recorded = {}
+
+    def fake_define_csv(args, header, rows, path, *a):
+        recorded["header"] = header
+        recorded["rows"] = rows
+
+    monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
+
+    args = types.SimpleNamespace(target="appl", output_file=None)
+
+    api_mod.host_util(None, args, "/tmp")
+
+    header = recorded["header"]
+    row = recorded["rows"][0]
+    index_map = {h: i for i, h in enumerate(header)}
+    for col in [
+        "Running Software Instances",
+        "Candidate Software Instances",
+        "Running Processes",
+        "Running Services (Windows)",
+    ]:
+        assert isinstance(row[index_map[col]], int)
+    assert "OS_Type" in header
+


### PR DESCRIPTION
## Summary
- include OS type in host utilisation query output
- convert host utilisation counts to integers for numeric CSV columns
- test host utilisation output formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689db8016f4083269d6108a212155716