### PR TITLE
Cast discovery run counters to ints and humanize CSV headers

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -186,13 +186,14 @@ def baseline(disco, args, dir):
                 # Failures
                 header = []
                 rows = []
+                header_hf = []
                 if "FAILED" in baseline['results']:
                     failures = baseline['results']['FAILED']
-                    header, rows = tools.json2csv(failures)
-                header.insert(0,"Discovery Instance")
+                    header, rows, header_hf = tools.json2csv(failures)
+                header_hf.insert(0, "Discovery Instance")
                 for row in rows:
                     row.insert(0, args.target)
-                output.define_csv(args,header,rows,dir+defaults.baseline_filename,args.output_file,args.target,"csv_file")
+                output.define_csv(args, header_hf, rows, dir + defaults.baseline_filename, args.output_file, args.target, "csv_file")
         except Exception as e:
             logger.error("Problem with baseline:\n%s\n%s"%(e.__class__,str(e)))
             # Try dumping it
@@ -352,13 +353,17 @@ def discovery_runs(disco, args, dir):
     if r:
         runs = json.loads(json.dumps(r))
         logger.debug('Runs:\n%s' % r)
-        header, rows = tools.json2csv(runs)
-        header.insert(0, "Discovery Instance")
+        for run in runs:
+            for field in ("done", "pre_scanning", "scanning", "total"):
+                if field in run:
+                    run[field] = int(run[field])
+        header, rows, header_hf = tools.json2csv(runs)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
         output.define_csv(
             args,
-            header,
+            header_hf,
             rows,
             dir + defaults.current_scans_filename,
             args.output_file,
@@ -390,6 +395,7 @@ def show_runs(disco, args):
             headers.append(key)
         parsed_runs.append(disco_run)
     headers = tools.sortlist(headers)
+    header_hf = [tools.snake_to_camel(h) for h in headers]
     run_csvs = []
     for run in parsed_runs:
         run_csv = []
@@ -417,7 +423,7 @@ def show_runs(disco, args):
             out_dir = getattr(args, "reporting_dir", "")
             output.define_csv(
                 args,
-                headers,
+                header_hf,
                 run_csvs,
                 os.path.join(out_dir, defaults.current_scans_filename),
                 getattr(args, "output_file", None),
@@ -438,17 +444,17 @@ def sensitive(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows = [], []
+    header, rows, header_hf = [], [], []
     if isinstance(results, list) and results:
-        header, rows = tools.json2csv(results)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(results)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
     else:
-        header.insert(0, "Discovery Instance")
+        header_hf.insert(0, "Discovery Instance")
     output.define_csv(
         args,
-        header,
+        header_hf,
         rows,
         dir + defaults.sensitive_data_filename,
         args.output_file,
@@ -465,17 +471,17 @@ def eca_errors(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows = [], []
+    header, rows, header_hf = [], [], []
     if isinstance(results, list) and results:
-        header, rows = tools.json2csv(results)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(results)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
     else:
-        header.insert(0, "Discovery Instance")
+        header_hf.insert(0, "Discovery Instance")
     output.define_csv(
         args,
-        header,
+        header_hf,
         rows,
         dir + defaults.eca_errors_filename,
         args.output_file,
@@ -489,17 +495,17 @@ def open_ports(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows = [], []
+    header, rows, header_hf = [], [], []
     if isinstance(results, list) and results:
-        header, rows = tools.json2csv(results)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(results)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
     else:
-        header.insert(0, "Discovery Instance")
+        header_hf.insert(0, "Discovery Instance")
     output.define_csv(
         args,
-        header,
+        header_hf,
         rows,
         dir + defaults.open_ports_filename,
         args.output_file,
@@ -513,17 +519,17 @@ def host_util(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows = [], []
+    header, rows, header_hf = [], [], []
     if isinstance(results, list) and results:
-        header, rows = tools.json2csv(results)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(results)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
     else:
-        header.insert(0, "Discovery Instance")
+        header_hf.insert(0, "Discovery Instance")
     output.define_csv(
         args,
-        header,
+        header_hf,
         rows,
         dir + defaults.host_util_filename,
         args.output_file,
@@ -540,16 +546,19 @@ def missing_vms(search, args, dir):
     if getattr(args, "resolve_hostnames", False):
         response = search_results(search, queries.missing_vms)
         if isinstance(response, list) and len(response) > 0:
-            header, data = tools.json2csv(response)
+            header, data, header_hf = tools.json2csv(response)
             header.insert(0, "Discovery Instance")
+            header_hf.insert(0, "Discovery Instance")
             for row in data:
                 row.insert(0, args.target)
 
             gf_index = header.index("Guest_Full_Name") if "Guest_Full_Name" in header else None
             header.append("Pingable")
+            header_hf.append("Pingable")
 
             devices = devices_lookup(search)
             header.extend(["last_identity", "last_scanned", "last_result"])
+            header_hf.extend(["Last Identity", "Last Scanned", "Last Result"])
 
             timer_count = 0
             for row in data:
@@ -580,7 +589,7 @@ def missing_vms(search, args, dir):
 
             output.define_csv(
                 args,
-                header,
+                header_hf,
                 data,
                 dir + defaults.missing_vms_filename,
                 args.output_file,
@@ -638,17 +647,17 @@ def device_capture_candidates(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows = [], []
+    header, rows, header_hf = [], [], []
     if isinstance(results, list) and results:
-        header, rows = tools.json2csv(results)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(results)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
     else:
-        header.insert(0, "Discovery Instance")
+        header_hf.insert(0, "Discovery Instance")
     output.define_csv(
         args,
-        header,
+        header_hf,
         rows,
         dir + defaults.device_capture_candidates_filename,
         args.output_file,

--- a/core/output.py
+++ b/core/output.py
@@ -223,11 +223,11 @@ def cmd2csv(header,result,seperator,filename,appliance):
 def query2csv(search, query, filename, appliance):
     response = api.search_results(search, query)
     if type(response) == list and len(response) > 0:
-        header, data = tools.json2csv(response)
-        header.insert(0,"Discovery Instance")
+        header, data, header_hf = tools.json2csv(response)
+        header_hf.insert(0, "Discovery Instance")
         for row in data:
             row.insert(0, appliance)
-        csv_file(data, header, filename)
+        csv_file(data, header_hf, filename)
     else:
         txt_dump("No results.",filename)
 

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1357,7 +1357,7 @@ def tpl_export(search, query, dir, method, client, sysuser, syspass):
     if method == "api":
         response = api.search_results(search, query)
         if type(response) == list and len(response) > 0:
-            header, data = tools.json2csv(response)
+            header, data, header_hf = tools.json2csv(response)
             for row in data:
                 filename = "%s/%s.tpl"%(tpldir,row[1])
                 files+=1

--- a/core/tools.py
+++ b/core/tools.py
@@ -10,6 +10,17 @@ from cidrize import cidrize
 
 logger = logging.getLogger("_tools_")
 
+def snake_to_camel(value):
+    """Convert snake_case string to Camel Case with spaces.
+
+    Examples:
+        >>> snake_to_camel("pre_scanning")
+        'Pre Scanning'
+    """
+    if not isinstance(value, str):
+        return value
+    return " ".join(word.capitalize() for word in value.split("_"))
+
 def in_wsl() -> bool:
     """
         WSL is thought to be the only common Linux kernel with Microsoft in the name, per Microsoft:
@@ -187,7 +198,7 @@ def json2csv(jsdata):
     header = []
     data = []
     for jsitem in jsdata:
-        headers = jsitem.keys() # get the headers, unstructured
+        headers = jsitem.keys()  # get the headers, unstructured
         for label in headers:
             # create a unique list of ALL possible headers
             header.append(label)
@@ -196,9 +207,10 @@ def json2csv(jsdata):
         values = []
         for key in header:
             # Loop through the unique set of headers and get values if exist
-            values.append(getr(jsitem,key,"N/A")) # Substitute if missing
+            values.append(getr(jsitem, key, "N/A"))  # Substitute if missing
         data.append(values)
-    return header, data
+    human_header = [snake_to_camel(h) for h in header]
+    return header, data, human_header
 
 def list_table_to_json(rows):
     """Convert a list-of-lists table to a list of dictionaries.

--- a/tests/test_missing_vms.py
+++ b/tests/test_missing_vms.py
@@ -75,5 +75,5 @@ def test_missing_vms_enriches_from_devices(monkeypatch):
 
     api_mod.missing_vms(DummySearch(), args, "")
 
-    assert captured["header"][-3:] == ["last_identity", "last_scanned", "last_result"]
+    assert captured["header"][-3:] == ["Last Identity", "Last Scanned", "Last Result"]
     assert captured["data"][0][-3:] == ["id1", "2024-01-01 10:00:00", "OK"]


### PR DESCRIPTION
## Summary
- convert discovery run counters to integers before CSV export
- add `snake_to_camel` helper and expose human-friendly headers from `json2csv`
- update API and output helpers to emit Camel Case headers and test coverage

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbde8419c8326a9be5153b5edce0b