### PR TITLE
Cast sysobjectid to numeric in device capture candidates

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -640,7 +640,24 @@ def device_capture_candidates(search, args, dir):
     print(os.linesep, end="\r")
     header, rows = [], []
     if isinstance(results, list) and results:
+        # Cast ``sysobjectid`` to a numeric type for csv output
+        for candidate in results:
+            if isinstance(candidate, dict):
+                value = candidate.get("sysobjectid")
+                try:
+                    candidate["sysobjectid"] = 0 if value is None else float(value)
+                except (ValueError, TypeError):
+                    candidate["sysobjectid"] = 0
+
         header, rows = tools.json2csv(results)
+
+        # ``json2csv`` treats ``0`` as a missing value.  Replace the
+        # generated entry with the numeric value to ensure it is preserved.
+        if "sysobjectid" in header:
+            idx = header.index("sysobjectid")
+            for candidate, row in zip(results, rows):
+                row[idx] = candidate.get("sysobjectid", 0)
+
         header.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -314,7 +314,7 @@ def test_device_capture_candidates_writes_csv(monkeypatch):
             "syscontact": None,
             "syslocation": None,
             "sysdescr": "HP ETHERNET MULTI-ENVIRONMENT",
-            "sysobjectid": "0.0",
+            "sysobjectid": 0.0,
         }
     ]
 
@@ -350,6 +350,31 @@ def test_device_capture_candidates_writes_csv(monkeypatch):
     assert captured["rows"][0] == expected_row
     assert captured["path"].endswith(api_mod.defaults.device_capture_candidates_filename)
 
+
+def test_device_capture_candidates_defaults_sysobjectid(monkeypatch):
+    results = [{"sysobjectid": None}]
+
+    monkeypatch.setattr(api_mod, "search_results", lambda *a, **k: results)
+    monkeypatch.setattr(api_mod.tools, "completage", lambda *a, **k: 0)
+
+    captured = {}
+
+    def fake_define_csv(args, header, rows, path, *a):
+        captured["header"] = header
+        captured["rows"] = rows
+
+    monkeypatch.setattr(
+        api_mod,
+        "output",
+        types.SimpleNamespace(define_csv=fake_define_csv),
+    )
+
+    args = types.SimpleNamespace(output_file=None, target="appl")
+
+    api_mod.device_capture_candidates(types.SimpleNamespace(), args, "/tmp")
+
+    idx = captured["header"].index("sysobjectid")
+    assert captured["rows"][0][idx] == 0
 
 def test_update_schedule_timezone_applies_offset():
     runs = [{"range_id": "r1", "schedule": {"start_times": [10, 23]}}]


### PR DESCRIPTION
## Summary
- Cast `sysobjectid` values to numeric when generating device capture candidate CSVs
- Default `sysobjectid` to 0 when missing or invalid
- Update and extend tests for numeric `sysobjectid` handling

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbdf76f388326ba3795deda446068