### PR TITLE
Humanize capture candidate headers

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -641,6 +641,7 @@ def device_capture_candidates(search, args, dir):
     header, rows = [], []
     if isinstance(results, list) and results:
         header, rows = tools.json2csv(results)
+        header = [tools.snake_to_title(h) for h in header]
         header.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)

--- a/core/queries.py
+++ b/core/queries.py
@@ -517,15 +517,15 @@ device_capture_candidates = """
                     search DiscoveryAccess where end_state = 'UnsupportedDevice' and _last_marker
                     traverse DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo where sysobjectid
                     show
-                    access_method,
-                    request_time,
-                    hostname,
-                    os,
-                    failure_reason,
-                    syscontact,
-                    syslocation,
-                    sysdescr,
-                    sysobjectid
+                    access_method as 'Access Method',
+                    request_time as 'Request Time',
+                    hostname as 'Hostname',
+                    os as 'OS',
+                    failure_reason as 'Failure Reason',
+                    syscontact as 'Syscontact',
+                    syslocation as 'Syslocation',
+                    sysdescr as 'Sysdescr',
+                    sysobjectid as 'Sysobject ID'
                 """
 
 missing_vms = """

--- a/core/tools.py
+++ b/core/tools.py
@@ -200,6 +200,36 @@ def json2csv(jsdata):
         data.append(values)
     return header, data
 
+def snake_to_title(value):
+    """Convert ``snake_case`` strings to Title Case with spaces.
+
+    Common abbreviations such as ``os`` and ``id`` are preserved in uppercase.
+    Non-string values or already formatted labels are returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+
+    if not value.islower():
+        return value
+
+    abbreviations = {"os": "OS", "id": "ID"}
+    parts = value.split("_")
+    words = []
+    for part in parts:
+        if part in abbreviations:
+            words.append(abbreviations[part])
+            continue
+        for abbr, repl in abbreviations.items():
+            if part.endswith(abbr) and part != abbr:
+                prefix = part[:-len(abbr)]
+                if prefix:
+                    words.append(prefix.capitalize())
+                words.append(repl)
+                break
+        else:
+            words.append(part.capitalize())
+    return " ".join(words)
+
 def list_table_to_json(rows):
     """Convert a list-of-lists table to a list of dictionaries.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.api import get_json, search_results, show_runs, get_outposts, map_outpost_credentials
 import core.api as api_mod
-from core import queries
+from core import queries, tools
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -338,7 +338,9 @@ def test_device_capture_candidates_writes_csv(monkeypatch):
 
     api_mod.device_capture_candidates(types.SimpleNamespace(), args, "/tmp")
 
-    expected_header = ["Discovery Instance"] + sorted(results[0].keys())
+    expected_header = ["Discovery Instance"] + [
+        tools.snake_to_title(k) for k in sorted(results[0].keys())
+    ]
     expected_row = [
         "appl"
     ] + [


### PR DESCRIPTION
## Summary
- Convert device capture candidate headers to Title Case with common abbreviations
- Alias capture candidate query fields with natural language labels
- Adjust tests for new header formatting

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dbdfd74d48326bd64894be24e1c47