### PR TITLE
Normalize headers and add reverse lookup mapping

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -389,12 +389,15 @@ def show_runs(disco, args):
             disco_run.update({key: run[key]})
             headers.append(key)
         parsed_runs.append(disco_run)
+
     headers = tools.sortlist(headers)
+    headers, lookup = tools.normalize_headers(headers)
+
     run_csvs = []
     for run in parsed_runs:
         run_csv = []
         for header in headers:
-            value = run.get(header)
+            value = run.get(lookup[header])
             run_csv.append(value)
         run_csvs.append(run_csv)
 
@@ -545,11 +548,11 @@ def missing_vms(search, args, dir):
             for row in data:
                 row.insert(0, args.target)
 
-            gf_index = header.index("Guest_Full_Name") if "Guest_Full_Name" in header else None
+            gf_index = header.index("Guest Full Name") if "Guest Full Name" in header else None
             header.append("Pingable")
 
             devices = devices_lookup(search)
-            header.extend(["last_identity", "last_scanned", "last_result"])
+            header.extend(["Last Identity", "Last Scanned", "Last Result"])
 
             timer_count = 0
             for row in data:

--- a/core/tools.py
+++ b/core/tools.py
@@ -183,21 +183,44 @@ def dequote(s):
         return s[1:-1]
     return s
 
-def json2csv(jsdata):
-    header = []
+def normalize_key(key):
+    """Return ``key`` converted from ``snake_case`` to spaced ``CamelCase``."""
+    parts = re.split(r"[_\.]+", key)
+    return " ".join(p.capitalize() for p in parts if p)
+
+
+def normalize_headers(headers):
+    """Normalize header labels and build a lookup to their original keys."""
+    normalized = []
+    lookup = {}
+    for key in headers:
+        norm = normalize_key(key)
+        normalized.append(norm)
+        lookup[norm] = key
+    return normalized, lookup
+
+
+def json2csv(jsdata, return_map=False):
+    orig_header = []
     data = []
     for jsitem in jsdata:
-        headers = jsitem.keys() # get the headers, unstructured
+        headers = jsitem.keys()  # get the headers, unstructured
         for label in headers:
             # create a unique list of ALL possible headers
-            header.append(label)
-            header = sortlist(header)
+            orig_header.append(label)
+            orig_header = sortlist(orig_header)
+
+    header, lookup = normalize_headers(orig_header)
+
     for jsitem in jsdata:
         values = []
-        for key in header:
+        for key in orig_header:
             # Loop through the unique set of headers and get values if exist
-            values.append(getr(jsitem,key,"N/A")) # Substitute if missing
+            values.append(getr(jsitem, key, "N/A"))  # Substitute if missing
         data.append(values)
+
+    if return_map:
+        return header, data, lookup
     return header, data
 
 def list_table_to_json(rows):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,7 @@ def test_show_runs_excavate_routes_to_define_csv(monkeypatch):
 
     show_runs(disco, args)
 
-    assert recorded["header"] == ["run_id", "status"]
+    assert recorded["header"] == ["Run Id", "Status"]
     assert recorded["data"] == [["1", "running"]]
 
 def test_get_outposts_uses_deleted_false():
@@ -338,7 +338,8 @@ def test_device_capture_candidates_writes_csv(monkeypatch):
 
     api_mod.device_capture_candidates(types.SimpleNamespace(), args, "/tmp")
 
-    expected_header = ["Discovery Instance"] + sorted(results[0].keys())
+    expected_header_norm, _ = api_mod.tools.normalize_headers(sorted(results[0].keys()))
+    expected_header = ["Discovery Instance"] + expected_header_norm
     expected_row = [
         "appl"
     ] + [

--- a/tests/test_missing_vms.py
+++ b/tests/test_missing_vms.py
@@ -75,5 +75,5 @@ def test_missing_vms_enriches_from_devices(monkeypatch):
 
     api_mod.missing_vms(DummySearch(), args, "")
 
-    assert captured["header"][-3:] == ["last_identity", "last_scanned", "last_result"]
+    assert captured["header"][-3:] == ["Last Identity", "Last Scanned", "Last Result"]
     assert captured["data"][0][-3:] == ["id1", "2024-01-01 10:00:00", "OK"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -34,3 +34,11 @@ def test_dequote_removes_quotes():
 def test_dequote_no_change():
     assert tools.dequote("hello") == "hello"
     assert tools.dequote("'hello'") == "'hello'"
+
+
+def test_json2csv_returns_normalized_headers_and_map():
+    data = [{"first_name": "Jane", "last_name": "Doe"}]
+    header, rows, lookup = tools.json2csv(data, return_map=True)
+    assert header == ["First Name", "Last Name"]
+    assert rows == [["Jane", "Doe"]]
+    assert lookup == {"First Name": "first_name", "Last Name": "last_name"}


### PR DESCRIPTION
## Summary
- normalize headers from JSON data to spaced CamelCase and provide reverse lookup mapping
- use normalized headers in API utilities and ensure consistent output
- expand tests for header normalization and mapping

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbe0d15688326acd76008e954036a