### PR TITLE
Normalize header output to CamelCase

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -415,9 +415,10 @@ def show_runs(disco, args):
     else:
         if getattr(args, "excavate", None):
             out_dir = getattr(args, "reporting_dir", "")
+            csv_headers = tools.normalize_keys(headers)
             output.define_csv(
                 args,
-                headers,
+                csv_headers,
                 run_csvs,
                 os.path.join(out_dir, defaults.current_scans_filename),
                 getattr(args, "output_file", None),
@@ -578,9 +579,10 @@ def missing_vms(search, args, dir):
                     row.extend(["N/A", "N/A", "N/A"])
             print(os.linesep, end="\r")
 
+            csv_header = tools.normalize_keys(header)
             output.define_csv(
                 args,
-                header,
+                csv_header,
                 data,
                 dir + defaults.missing_vms_filename,
                 args.output_file,
@@ -646,9 +648,10 @@ def device_capture_candidates(search, args, dir):
             row.insert(0, args.target)
     else:
         header.insert(0, "Discovery Instance")
+    csv_header = tools.normalize_keys(header)
     output.define_csv(
         args,
-        header,
+        csv_header,
         rows,
         dir + defaults.device_capture_candidates_filename,
         args.output_file,

--- a/core/output.py
+++ b/core/output.py
@@ -256,6 +256,8 @@ def define_txt(args,result,path,filename):
 def define_csv(args,head_ep,data,path,file,target,type):
     # Manage all Output options
     cli_out = getattr(args, "output_cli", False)
+    if isinstance(head_ep, list):
+        head_ep = tools.normalize_keys(head_ep)
     if type == "cmd":
         if args.output_file:
             cmd2csv(head_ep, data, ":", file, target)

--- a/core/tools.py
+++ b/core/tools.py
@@ -210,3 +210,20 @@ def list_table_to_json(rows):
         headers = rows[0]
         return [dict(zip(headers, r)) for r in rows[1:]]
     return rows
+
+
+def normalize_keys(keys):
+    """Return header names in Title Case with spaces.
+
+    Any key containing underscores or entirely lowercase characters is
+    converted to a human-friendly form. Keys that already contain
+    capital letters or spaces are returned unchanged.
+    """
+
+    normalized = []
+    for key in keys:
+        if "_" in key or key.islower():
+            normalized.append(key.replace("_", " ").title())
+        else:
+            normalized.append(key)
+    return normalized

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from core.api import get_json, search_results, show_runs, get_outposts, map_outpost_credentials
 import core.api as api_mod
 from core import queries
+from core.tools import normalize_keys
 
 class DummyResponse:
     def __init__(self, status_code=200, data="{}", reason="OK", url="http://x"):
@@ -145,7 +146,7 @@ def test_show_runs_excavate_routes_to_define_csv(monkeypatch):
 
     show_runs(disco, args)
 
-    assert recorded["header"] == ["run_id", "status"]
+    assert recorded["header"] == normalize_keys(["run_id", "status"])
     assert recorded["data"] == [["1", "running"]]
 
 def test_get_outposts_uses_deleted_false():
@@ -338,12 +339,13 @@ def test_device_capture_candidates_writes_csv(monkeypatch):
 
     api_mod.device_capture_candidates(types.SimpleNamespace(), args, "/tmp")
 
-    expected_header = ["Discovery Instance"] + sorted(results[0].keys())
+    keys = sorted(results[0])
+    expected_header = ["Discovery Instance"] + normalize_keys(keys)
     expected_row = [
         "appl"
     ] + [
         (results[0][k] if results[0][k] is not None else "N/A")
-        for k in sorted(results[0])
+        for k in keys
     ]
 
     assert captured["header"] == expected_header

--- a/tests/test_missing_vms.py
+++ b/tests/test_missing_vms.py
@@ -10,6 +10,7 @@ sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import core.api as api_mod
+from core.tools import normalize_keys
 
 class DummySearch:
     def search(self, query, format="object", limit=500):
@@ -75,5 +76,9 @@ def test_missing_vms_enriches_from_devices(monkeypatch):
 
     api_mod.missing_vms(DummySearch(), args, "")
 
-    assert captured["header"][-3:] == ["last_identity", "last_scanned", "last_result"]
+    assert captured["header"][-3:] == normalize_keys([
+        "last_identity",
+        "last_scanned",
+        "last_result",
+    ])
     assert captured["data"][0][-3:] == ["id1", "2024-01-01 10:00:00", "OK"]


### PR DESCRIPTION
## Summary
- add `normalize_keys` utility to convert snake_case keys to title case
- normalize CSV headers across API outputs
- update tests to expect CamelCase headers using shared helper

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbe12a07c8326821a5258ca33cc45