### PR TITLE
Expose raw discovery timestamps in analysis output

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -127,6 +127,7 @@ last_disco = {
                     friendlyTime(#Member:List:List:DiscoveryRun.endtime) as 'Run_Endtime',
                     friendlyTime(discovery_starttime) as 'Scan_Starttime',
                     friendlyTime(discovery_endtime) as 'Scan_Endtime',
+                    discovery_endtime as 'Scan_Endtime_Raw',
                     whenWasThat(discovery_endtime) as 'When_Last_Scan',
                     (#DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo.last_access_method in ['windows', 'rcmd']
                         and #DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo.last_slave
@@ -174,6 +175,7 @@ dropped_endpoints = """
                     __reason as 'End_State',
                     friendlyTime(starttime) as 'Start',
                     friendlyTime(endtime) as 'End',
+                    endtime as 'End_Raw',
                     whenWasThat(endtime) as 'When_Last_Scan',
                     #EndpointRange:EndpointRange:DiscoveryRun:DiscoveryRun.label as "Run"
                 """

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -185,7 +185,16 @@ def test_discovery_access_with_dropped_only(monkeypatch):
         if query is reporting.queries.last_disco:
             return []
         if query is reporting.queries.dropped_endpoints:
-            return [{"Endpoint": "1.2.3.4", "End": "2024-01-01 00:00:00", "Run": "r", "Start": "2024-01-01 00:00:00", "End_State": "DarkSpace"}]
+            return [
+                {
+                    "Endpoint": "1.2.3.4",
+                    "End": "2024-01-01 00:00:00",
+                    "End_Raw": "2024-01-01T00:00:00+00:00",
+                    "Run": "r",
+                    "Start": "2024-01-01 00:00:00",
+                    "End_State": "DarkSpace",
+                }
+            ]
         return []
 
     monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
@@ -201,3 +210,75 @@ def test_discovery_access_with_dropped_only(monkeypatch):
     reporting.discovery_access(DummySearch(), DummyCreds(), args)
 
     assert "ran" in called
+
+
+def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
+    class DummyDF(dict):
+        def __init__(self, data):
+            super().__init__({k: {0: v[0] if isinstance(v, list) else v} for k, v in data.items()})
+
+        def __getitem__(self, key):
+            return self.get(key)
+
+        def __setitem__(self, key, value):
+            dict.__setitem__(self, key, {0: value})
+
+        def to_dict(self):
+            return self
+
+    monkeypatch.setattr(reporting.builder, "unique_identities", lambda s, *a, **k: [])
+
+    def fake_search_results(search, query):
+        if query is reporting.queries.last_disco:
+            return [
+                {
+                    "Endpoint": "1.1.1.1",
+                    "Scan_Endtime": "2024-01-01 00:00:00",
+                    "Scan_Endtime_Raw": "2024-01-01T00:00:00+00:00",
+                    "End_State": "OK",
+                }
+            ]
+        if query is reporting.queries.dropped_endpoints:
+            return [
+                {
+                    "Endpoint": "2.2.2.2",
+                    "End": "2024-01-02 00:00:00",
+                    "End_Raw": "2024-01-02T00:00:00+00:00",
+                    "Run": "r",
+                    "Start": "2024-01-02 00:00:00",
+                    "End_State": "DarkSpace",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.api, "map_outpost_credentials", lambda *a, **k: {})
+    monkeypatch.setattr(reporting.pd, "DataFrame", lambda data: DummyDF(data), raising=False)
+    monkeypatch.setattr(reporting.pd, "cut", lambda *a, **k: "recent", raising=False)
+
+    captured = {}
+
+    def fake_report(data, headers, args, name=""):
+        captured["data"] = data
+        captured["headers"] = headers
+
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=fake_report))
+
+    args = types.SimpleNamespace(
+        output_csv=True,
+        output_file=None,
+        token=None,
+        target="http://x",
+        include_endpoints=None,
+        endpoint_prefix=None,
+    )
+
+    reporting.discovery_analysis(DummySearch(), DummyCreds(), args)
+
+    idx = captured["headers"].index("scan_end_raw")
+    disco_row = next(row for row in captured["data"] if row[0] == "1.1.1.1")
+    dropped_row = next(row for row in captured["data"] if row[0] == "2.2.2.2")
+
+    assert disco_row[idx] == "2024-01-01T00:00:00+00:00"
+    assert dropped_row[idx] == "2024-01-02T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- capture `Scan_Endtime_Raw` and `End_Raw` in discovery queries
- parse and propagate raw discovery end timestamps through `_gather_discovery_data`
- surface raw timestamps in `discovery_analysis` CSV output and extend tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dbe2739fc8326b8b97cbc1fe57fad