### PR TITLE
Surface OS type in orphan VM query

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -297,6 +297,7 @@ orphan_vms = """
                     hostname,
                     hash(hostname) as 'hashed_hostname',
                     os,
+                    #InferredElement:Inference:Associate:DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo.os_type as 'OS_Type',
                     virtual,
                     cloud,
                     #InferredElement:Inference:Associate:DiscoveryAccess.endpoint as 'endpoint',

--- a/tests/test_orphan_vms.py
+++ b/tests/test_orphan_vms.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import types
+
+# Stub modules that may not be installed
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.api as api_mod
+import core.cli as cli_mod
+
+
+class DummySearch:
+    def search(self, query, format="object", limit=500):
+        return types.SimpleNamespace(json=lambda: [])
+
+
+def test_api_orphan_vms_includes_os_type(monkeypatch):
+    captured = {}
+
+    def fake_search_results(search, query):
+        captured["query"] = query
+        return [
+            {
+                "hostname": "h1",
+                "os": "Linux",
+                "OS_Type": "Unix",
+                "virtual": True,
+                "cloud": False,
+                "endpoint": "ep",
+                "vendor": "v",
+                "vm_class": "class",
+            }
+        ]
+
+    def fake_csv_file(data, header, filename):
+        captured["header"] = header
+        captured["data"] = data
+
+    monkeypatch.setattr(api_mod, "search_results", fake_search_results)
+    monkeypatch.setattr(api_mod.output, "csv_file", fake_csv_file)
+
+    args = types.SimpleNamespace(
+        output_file=None,
+        output_csv=None,
+        output_null=False,
+        output_cli=False,
+        target="t",
+    )
+
+    api_mod.orphan_vms(DummySearch(), args, "")
+
+    assert "DeviceInfo.os_type" in captured["query"]
+    assert "OS_Type" in captured["header"]
+
+
+def test_cli_orphan_vms_includes_os_type(monkeypatch):
+    captured = {}
+
+    def fake_run_query(client, user, passwd, query):
+        captured["query"] = query
+        return (
+            "hostname,os,OS_Type,virtual,cloud,endpoint,vendor,vm_class\n"
+            "h1,Linux,Unix,true,false,ep,v,class"
+        )
+
+    def fake_save2csv(clidata, filename, appliance):
+        header = clidata.split("\n", 1)[0].split(",")
+        captured["header"] = header
+
+    monkeypatch.setattr(cli_mod, "run_query", fake_run_query)
+    monkeypatch.setattr(cli_mod.output, "save2csv", fake_save2csv)
+
+    args = types.SimpleNamespace(
+        output_file=None,
+        output_csv=None,
+        output_null=False,
+        output_cli=False,
+        target="t",
+    )
+
+    cli_mod.orphan_vms(object(), args, "u", "p", "")
+
+    assert "DeviceInfo.os_type" in captured["query"]
+    assert "OS_Type" in captured["header"]
+


### PR DESCRIPTION
## Summary
- expose each VM's OS type in the `orphan_vms` query output
- add regression tests ensuring `dq_orphan_vms` includes `OS_Type` for both API and CLI paths

## Testing
- `python - <<'PY'
import types, os
import core.api as api_mod

os.makedirs('api', exist_ok=True)
args=types.SimpleNamespace(output_file=None, output_csv=None, output_null=False, output_cli=False, target='t')

def fake_search_results(search, query):
    print('API query contains OS_Type:', 'OS_Type' in query)
    return [{
        'hostname':'vm1','hashed_hostname':'h','os':'Linux','OS_Type':'Unix','virtual':True,'cloud':False,
        'endpoint':'ep','vendor':'v','vm_class':'class'
    }]
api_mod.search_results = fake_search_results
api_mod.orphan_vms(object(), args, 'api')
with open('api/dq_orphan_vms.csv') as f:
    print('CSV header:', f.readline().strip())
os.remove('api/dq_orphan_vms.csv')
PY`
- `python - <<'PY'
import types, os
import core.api as api_mod
import core.cli as cli_mod

os.makedirs('cli', exist_ok=True)
args = types.SimpleNamespace(output_file=None, output_csv=None, output_null=False, output_cli=False, target='t')

def fake_run_query(client, user, passwd, query):
    print('CLI query contains OS_Type:', 'OS_Type' in query)
    return (
        'hostname,os,OS_Type,virtual,cloud,endpoint,vendor,vm_class\n'
        'vm1,Linux,Unix,true,false,ep,v,class'
    )
cli_mod.run_query = fake_run_query
cli_mod.orphan_vms(object(), args, 'u', 'p', 'cli')
with open('cli/dq_orphan_vms.csv') as f:
    print('CSV header:', f.readline().strip())
os.remove('cli/dq_orphan_vms.csv')
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dbe2e884c83268a9397520cafe4d8