### PR TITLE
Ensure consecutive scan failures numeric output

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -332,7 +332,7 @@ near_removal = """
                     (#InferredElement:Inference:Associate:DiscoveryAccess.endpoint or 'DDD Aged Out') as 'Last Successful IP',
                     whenWasThat(last_update_success) as 'Last Successful Scan',
                     last_update_success as 'Last Successful Scan Date',
-                    age_count * -1 as 'Consecutive Scan Failures',
+                    value(age_count * -1) as 'Consecutive Scan Failures',
                     (@scans > 0 and @time_to_doom > 0 and #'%d scans, %d hours'(@scans,@time_to_doom)
                     or @scans > 0 and #'%d scans'(@scans) or @time_to_doom > 0 and #'%d hours'(@time_to_doom)
                     or 'Next unsuccessful scan') as 'Removal Eligibility'

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,10 +1,11 @@
 import os
+import csv
 import sys
 import types
 
 sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
 sys.modules.setdefault("core.api", types.SimpleNamespace())
-sys.modules.setdefault("core.tools", types.SimpleNamespace())
+sys.modules.setdefault("core.tools", types.SimpleNamespace(dequote=lambda s: s.strip('"')))
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -46,3 +47,12 @@ def test_format_duration_units():
     assert output.format_duration(45) == "45.00 seconds"
     assert output.format_duration(120) == "2.00 minutes"
     assert output.format_duration(7200) == "2.00 hours"
+
+
+def test_save2csv_numeric(tmp_path):
+    clidata = "Consecutive Scan Failures\n-5\r\n"
+    filename = tmp_path / "out.csv"
+    output.save2csv(clidata, str(filename), "appliance")
+    with open(filename, newline="") as fh:
+        row = next(csv.DictReader(fh))
+    assert int(row["Consecutive Scan Failures"]) == -5


### PR DESCRIPTION
## Summary
- ensure consecutive scan failures query is evaluated numerically
- test CSV export emits numeric consecutive scan failures

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc49a79288326948b65d1bc727b30