### PR TITLE
Rename overlapping IP report to ip analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Two related reports focus on Discovery Access history:
 
 - **discovery_access** – exports the latest access details for each endpoint, including credential information and timestamps.
 - **discovery_analysis** – adds a comparison between consecutive runs using the same data to highlight state changes.
-- **overlapping_ips** – analyze overlapping discovery ranges and report unscheduled endpoints. Uses the same data sources as the schedules report.
+- **ip_analysis** – Run IP analysis report.
 More reports are included.
 Run `python3 dismal.py --help` to see the complete list.

--- a/core/builder.py
+++ b/core/builder.py
@@ -794,12 +794,12 @@ def unique_identities(search, include_endpoints=None, endpoint_prefix=None):
 
     return unique_identities
 
-def overlapping(tw_search, args):
+def ip_analysis(tw_search, args):
 
-    print("\nScheduled Scans Overlapping")
-    print("---------------------------")
-    logger.info("Running: Overlapping Report...")
-    print("Running: Overlapping Report...")
+    print("\nIP Analysis")
+    print("-----------")
+    logger.info("Running: IP analysis report...")
+    print("Running: IP analysis report...")
     heads = ["IP Address", "Scan Schedules"]
 
     logger.debug("Executing scan range query: %s", queries.scanrange.get("query", queries.scanrange))
@@ -809,7 +809,7 @@ def overlapping(tw_search, args):
     logger.debug("Raw scan range results: %s", scan_ranges)
     if scan_ranges is None or not isinstance(scan_ranges, list):
         logger.error("Failed to retrieve scan ranges")
-        output.report([], heads, args, name="overlapping_ips")
+        output.report([], heads, args, name="ip_analysis")
         return
     if len(scan_ranges) == 0:
         msg = "No scan ranges found"
@@ -858,7 +858,7 @@ def overlapping(tw_search, args):
     logger.debug("Raw exclude results: %s", excludes)
     if excludes is None or not isinstance(excludes, list):
         logger.error("Failed to retrieve excludes")
-        output.report([], heads, args, name="overlapping_ips")
+        output.report([], heads, args, name="ip_analysis")
         return
     if len(excludes) == 0:
         msg = "No exclude ranges found"
@@ -869,7 +869,7 @@ def overlapping(tw_search, args):
         e = excludes[0]
         if not isinstance(e, dict) or 'results' not in e:
             logger.error("Invalid excludes result structure")
-            output.report([], heads, args, name="overlapping_ips")
+            output.report([], heads, args, name="ip_analysis")
             return
 
     logger.debug("Parsed %d exclude results", len(e.get("results", [])))
@@ -917,7 +917,7 @@ def overlapping(tw_search, args):
         logger.info(msg)
         print(msg)
 
-    output.report(data, heads, args, name="overlapping_ips")
+    output.report(data, heads, args, name="ip_analysis")
 
 def get_scans(results, list_of_ranges):
     """Return labels of scans that include any of ``list_of_ranges``.

--- a/dismal.py
+++ b/dismal.py
@@ -143,7 +143,7 @@ Providing no <report> or using "default" will run all options that do not requir
 "open_ports"                - Export of open ports analysis
 "orphan_vms"                - Report of Virtual Machines that are not related to a container Host
 "os_lifecycle"              - Export OS lifecycle report
-"overlapping_ips"           - Run overlapping range analysis report
+"ip_analysis"               - Run IP analysis report
 "pattern_modules"           - Summary of installed pattern modules
 "removed"                   - Export list of devices removed in the last 7 days (aged out)
 "schedules"                 - Export of schedules with additional list of which credentials will be used with scan/exclude
@@ -332,7 +332,7 @@ if args.access_method == "all":
         api.success(creds, search, args, reporting_dir)
         builder.scheduling(creds, search, args)
         api.excludes(search, args, reporting_dir)
-        builder.overlapping(search, args)
+        builder.ip_analysis(search, args)
         reporting.discovery_access(search, creds, args)
         reporting.discovery_analysis(search, creds, args)
         api.show_runs(disco, args)
@@ -633,8 +633,8 @@ if args.access_method=="api":
     if excavate_default or (args.excavate and args.excavate[0] == "excludes"):
         api.excludes(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "overlapping_ips"):
-        builder.overlapping(search, args)
+    if excavate_default or (args.excavate and args.excavate[0] == "ip_analysis"):
+        builder.ip_analysis(search, args)
 
     # Gather discovery data once and reuse for both reporting calls.
     disco_data = None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -28,7 +28,7 @@ class DummySearch:
         return DummyResponse()
 
 
-def test_overlapping_handles_bad_api(monkeypatch):
+def test_ip_analysis_handles_bad_api(monkeypatch):
     called = {}
 
     def fake_report(*a, **k):
@@ -38,7 +38,7 @@ def test_overlapping_handles_bad_api(monkeypatch):
     args = types.SimpleNamespace(output_csv=False, output_file=None)
 
     # Should not raise even though API call fails
-    builder.overlapping(DummySearch(), args)
+    builder.ip_analysis(DummySearch(), args)
 
     # When the API call fails the function should still report an empty result
     assert "ran" in called
@@ -102,7 +102,7 @@ def _setup_schedule_patches(monkeypatch, cred_list, excludes, scan_ranges):
     return vault, search, args, captured
 
 
-def _setup_overlap_patches(monkeypatch, scan_ranges, excludes):
+def _setup_ip_analysis_patches(monkeypatch, scan_ranges, excludes):
     seq = iter([scan_ranges, excludes])
 
     monkeypatch.setattr(builder.api, "get_json", lambda *a, **k: next(seq))
@@ -233,7 +233,7 @@ def test_scheduling_scan_ranges_no_results_key(monkeypatch):
     assert any(row[1] == "Scan Range" for row in captured["data"])
 
 
-def test_overlapping_scan_ranges_no_results_key(monkeypatch):
+def test_ip_analysis_scan_ranges_no_results_key(monkeypatch):
     scan_ranges = [{"Scan_Range": ["10.0.0.0/24"], "ID": 1, "Label": "r", "Level": "L", "Date_Rules": ""}]
     excludes = [{"results": []}]
 
@@ -260,26 +260,26 @@ def test_overlapping_scan_ranges_no_results_key(monkeypatch):
     search = types.SimpleNamespace(search=lambda *a, **k: None)
     args = types.SimpleNamespace(output_csv=False, output_file=None)
 
-    builder.overlapping(search, args)
+    builder.ip_analysis(search, args)
 
     assert "data" in called
 
 
-def test_overlapping_empty_excludes(monkeypatch, capsys):
+def test_ip_analysis_empty_excludes(monkeypatch, capsys):
     scan_ranges = [{"results": [{"Scan_Range": ["10.0.0.0/24"], "ID": 1, "Label": "r", "Level": "L", "Date_Rules": ""}]}]
-    search, args, captured = _setup_overlap_patches(monkeypatch, scan_ranges, [])
+    search, args, captured = _setup_ip_analysis_patches(monkeypatch, scan_ranges, [])
 
-    builder.overlapping(search, args)
+    builder.ip_analysis(search, args)
     out = capsys.readouterr().out
 
     assert "No exclude ranges found" in out
     assert captured["data"] == []
 
 
-def test_overlapping_empty_scan_ranges(monkeypatch, capsys):
-    search, args, captured = _setup_overlap_patches(monkeypatch, [], [{"results": []}])
+def test_ip_analysis_empty_scan_ranges(monkeypatch, capsys):
+    search, args, captured = _setup_ip_analysis_patches(monkeypatch, [], [{"results": []}])
 
-    builder.overlapping(search, args)
+    builder.ip_analysis(search, args)
     out = capsys.readouterr().out
 
     assert "No scan ranges found" in out


### PR DESCRIPTION
## Summary
- replace `overlapping_ips` CLI option with `ip_analysis`
- rename builder.overlapping function to `ip_analysis`
- adjust tests and docs for `ip_analysis`

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbff977d08326bb53be4bc64639e5