### PR TITLE
Use numeric counts in schedule report

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -573,12 +573,16 @@ def scheduling(vault, search, args):
         in_exclude = tools.sortlist(in_exclude)
         logger.debug("Excludes:%s"%(in_exclude))
 
+        range_count = len(fr or [])
+        cred_count = len(in_exclude)
         if args.output_csv or args.output_file:
             msg = os.linesep
-            data.append([ sc, "Exclude Range", i, fr, None, dr, in_exclude ])
         else:
-            msg = "\nOnly showing ranges, credential counts for tables output. Output to CSV for credential list.\n"
-            data.append([ sc, "Exclude Range", i, len(fr), None, dr, len(in_exclude) ])
+            msg = (
+                "\nOnly showing ranges, credential counts for tables output. "
+                "Output to CSV for credential list.\n"
+            )
+        data.append([sc, "Exclude Range", i, range_count, None, dr, cred_count])
     if timer_count > 0:
         print(os.linesep,end="\r")
     
@@ -638,12 +642,16 @@ def scheduling(vault, search, args):
         in_run = tools.sortlist(in_run)
         logger.debug("Runs:%s"%(in_run))
         
+        range_count = len(fr or [])
+        cred_count = len(in_run)
         if args.output_csv or args.output_file:
             msg = os.linesep
-            data.append([ sc, "Scan Range", i, fr, sl, dr, in_run ])
         else:
-            msg = "\nOnly showing ranges, credential counts for tables output. Output to CSV for credential list.\n"
-            data.append([ sc, "Scan Range", i, len(fr), sl, dr, len(in_run) ])
+            msg = (
+                "\nOnly showing ranges, credential counts for tables output. "
+                "Output to CSV for credential list.\n"
+            )
+        data.append([sc, "Scan Range", i, range_count, sl, dr, cred_count])
     print(os.linesep,end="\r")
 
     # sort data by index field

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -233,6 +233,41 @@ def test_scheduling_scan_ranges_no_results_key(monkeypatch):
     assert any(row[1] == "Scan Range" for row in captured["data"])
 
 
+def test_scheduling_counts_numeric(monkeypatch):
+    cred = [{"uuid": "u1", "label": "c1", "index": 1, "ip_range": "10.0.0.0/24"}]
+    excludes = [
+        {
+            "results": [
+                {"Scan_Range": ["10.0.0.0/24"], "ID": 1, "Label": "ex", "Date_Rules": ""}
+            ]
+        }
+    ]
+    scan_ranges = [
+        {
+            "results": [
+                {
+                    "Scan_Range": ["10.0.0.0/24"],
+                    "ID": 2,
+                    "Label": "sr",
+                    "Level": "L",
+                    "Date_Rules": "",
+                }
+            ]
+        }
+    ]
+
+    vault, search, args, captured = _setup_schedule_patches(
+        monkeypatch, cred, excludes, scan_ranges
+    )
+    args.output_csv = True
+
+    builder.scheduling(vault, search, args)
+
+    for row in captured["data"]:
+        assert isinstance(row[3], int)
+        assert isinstance(row[6], int)
+
+
 def test_overlapping_scan_ranges_no_results_key(monkeypatch):
     scan_ranges = [{"Scan_Range": ["10.0.0.0/24"], "ID": 1, "Label": "r", "Level": "L", "Date_Rules": ""}]
     excludes = [{"results": []}]


### PR DESCRIPTION
## Summary
- output counts for ranges and credentials in schedule report instead of string lists
- test that schedule report columns are numeric

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dbc0be47c832681f36dad07965bc2