### PR TITLE
Add progress tracking for device result processing

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -427,6 +427,7 @@ def devices(twsearch, twcreds, args):
     for identity in identities:
         timer_count = tools.completage("Gathering Device Results...", len(identities), timer_count)
         logger.debug("Processing identity %s"%identity)
+        result_timer = 0  # Reset result progress counter for each identity
         latest_timestamp = None
         all_credentials_used = []
         all_discovery_runs = []
@@ -436,7 +437,7 @@ def devices(twsearch, twcreds, args):
         last_scanned_ip = None
         last_kind = None
         for result in results:
-
+            result_timer = tools.completage("Processing device results…", len(results), result_timer)
             da_endpoint = tools.getr(result,'DA_Endpoint',None)
             logger.debug("Checking endpoint %s in identity %s"%(da_endpoint,identity))
 


### PR DESCRIPTION
## Summary
- track device result processing with secondary timer
- update progress indicator for each result while resetting timer per identity

## Testing
- `python3 -m pytest` *(fails: UnboundLocalError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689df58c63ec83269e9fd7a5fa9c0b89