### PR TITLE
Fix normalization helper to return list or lookup and update callers

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -393,7 +393,7 @@ def show_runs(disco, args):
         parsed_runs.append(disco_run)
 
     headers = tools.sortlist(headers)
-    headers, lookup = tools.normalize_headers(headers)
+    headers, lookup = tools.normalize_headers(headers, return_lookup=True)
     header_hf = [tools.snake_to_camel(h) for h in headers]
     run_csvs = []
     for run in parsed_runs:

--- a/core/builder.py
+++ b/core/builder.py
@@ -365,7 +365,7 @@ def ordering(creds, search, args, apply):
         # ``normalize_headers`` returns ``(headers, lookup)`` with headers in
         # Title Case. Convert the header names to a mutable list and then to
         # CamelCase so we can safely insert additional labels.
-        headers = list(tools.normalize_headers(headers)[0])
+        headers = list(tools.normalize_headers(headers, return_lookup=True)[0])
         headers = [tools.normalize_header(h) for h in headers]
         headers.insert(0, "Discovery Instance")
         for row in data:


### PR DESCRIPTION
## Summary
- ensure `normalize_headers` can optionally return a lookup map and default to a list
- update JSON-to-CSV conversion to use new normalization helper
- adjust builder and API to use updated helper

## Testing
- `python -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_capture_candidates_writes_csv, test_device_capture_candidates_defaults_sysobjectid, test_host_util_converts_numeric_columns, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type, test_discovery_access_handles_bad_api, test_discovery_analysis_includes_raw_timestamp)*

------
https://chatgpt.com/codex/tasks/task_e_689f2d5894cc83268d712fd501c667a7