### PR TITLE
Fix discovery_runs header handling

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -353,9 +353,8 @@ def discovery_runs(disco, args, dir):
     if r:
         runs = json.loads(json.dumps(r))
         logger.debug('Runs:\n%s' % r)
-        header, rows = tools.json2csv(runs)
-        header = tools.normalize_headers(header)
-        header.insert(0, "Discovery Instance")
+        header, rows, header_hf = tools.json2csv(runs)
+        header_hf.insert(0, "Discovery Instance")
         for row in rows:
             row.insert(0, args.target)
         output.define_csv(


### PR DESCRIPTION
## Summary
- capture human-friendly header list from `json2csv`
- insert Discovery Instance into human-friendly header list
- remove redundant header normalization

## Testing
- `python3 -m pytest` *(fails: TypeError in show_runs, multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e2b7ffbc8326b27b2261da3f9759