### PR TITLE
Add 7-day credential success metrics

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -20,6 +20,27 @@ deviceinfo_success = """
                           access_method as 'Session_Type'
                           process with countUnique(1,0)
                        """
+credential_success_7d = """
+                            search SessionResult where success and time_index > (currentTime() - 7*24*3600*10000000)
+                            show (slave or credential) as 'UUID',
+                            session_type as 'Session_Type'
+                            processwith countUnique(1,0)
+                        """
+credential_failure_7d = """
+                            search SessionResult where not success and time_index > (currentTime() - 7*24*3600*10000000)
+                            show (slave or credential) as 'UUID',
+                            session_type as 'Session_Type'
+                            processwith countUnique(1,0)
+                        """
+deviceinfo_success_7d = """
+                          search DeviceInfo where method_success and __had_inference
+                          and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess
+                                            traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
+                          and time_index > (currentTime() - 7*24*3600*10000000)
+                          show (last_credential or last_slave) as 'UUID',
+                          access_method as 'Session_Type'
+                          process with countUnique(1,0)
+                       """
 deviceInfo = {"query":
                         """
                             search DeviceInfo

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -130,6 +130,12 @@ def test_successful_combines_query_results(monkeypatch):
             return [{"UUID": "u1", "Session_Type": "ssh", "Count": 3}]
         if query is reporting.queries.credential_failure:
             return [{"UUID": "u1", "Session_Type": "ssh", "Count": 4}]
+        if query is reporting.queries.credential_success_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 1}]
+        if query is reporting.queries.deviceinfo_success_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 1}]
+        if query is reporting.queries.credential_failure_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 1}]
         return []
 
     call = {"n": 0}
@@ -172,11 +178,16 @@ def test_successful_combines_query_results(monkeypatch):
         reporting.queries.credential_success,
         reporting.queries.deviceinfo_success,
         reporting.queries.credential_failure,
+        reporting.queries.credential_success_7d,
+        reporting.queries.deviceinfo_success_7d,
+        reporting.queries.credential_failure_7d,
     }
+    assert "Success % 7 days" in captured["headers"]
     row = captured["data"][0]
     assert row[6] == 5
     assert row[7] == 4
     assert row[8] == pytest.approx(5 / 9)
+    assert row[9] == pytest.approx(2 / 3)
 
 
 def test_successful_coerces_string_counts(monkeypatch):
@@ -189,6 +200,12 @@ def test_successful_coerces_string_counts(monkeypatch):
             return [{"UUID": "u1", "Session_Type": "ssh", "Count": "3"}]
         if query is reporting.queries.credential_failure:
             return [{"UUID": "u1", "Session_Type": "ssh", "Count": "4"}]
+        if query is reporting.queries.credential_success_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": "1"}]
+        if query is reporting.queries.deviceinfo_success_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": "1"}]
+        if query is reporting.queries.credential_failure_7d:
+            return [{"UUID": "u1", "Session_Type": "ssh", "Count": "1"}]
         return []
 
     call = {"n": 0}
@@ -239,6 +256,7 @@ def test_successful_coerces_string_counts(monkeypatch):
     assert isinstance(row[6], int)
     assert isinstance(row[7], int)
     assert isinstance(row[8], float)
+    assert isinstance(row[9], float)
 
 
 def test_successful_uses_token_file(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add 7-day credential and device info queries with time filters
- compute and report 7-day success statistics alongside all-time metrics
- extend reporting tests for new 7-day success column

## Testing
- `python3 -m pytest` *(fails: test_api::test_show_runs_excavate_routes_to_define_csv, test_api::test_discovery_runs_emits_ints_and_camel_headers, test_api::test_capture_candidates_writes_csv, test_api::test_device_capture_candidates_defaults_sysobjectid, test_builder::test_ip_analysis_empty_excludes, test_builder::test_ip_analysis_empty_scan_ranges, test_builder::test_overlapping_unscanned_connections, test_discovery_dedupe::test_prefers_named_and_updates_timestamp, test_discovery_dedupe::test_picks_latest_when_no_names, test_orphan_vms::test_api_orphan_vms_includes_os_type, test_orphan_vms::test_cli_orphan_vms_includes_os_type)`

------
https://chatgpt.com/codex/tasks/task_e_68a5941aad2c832684ae7dcfdc01a13b