### PR TITLE
Rename suggested credential optimization command

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -371,7 +371,10 @@ def ordering(creds, search, args, apply):
         for row in data:
             row.insert(0, getattr(args, "target", None))
 
-    output.report(data, headers, args, name="suggest_cred_opt")
+    # Export the suggested credential optimisation report using the new
+    # ``suggested_cred_opt`` key so downstream consumers and the CLI can
+    # reference a consistent name.
+    output.report(data, headers, args, name="suggested_cred_opt")
 
 def get_device(search, credentials, args):
     dev = args.excavate[1]

--- a/dismal.py
+++ b/dismal.py
@@ -149,7 +149,7 @@ Providing no <report> or using "default" will run all options that do not requir
 "sensitive_data"            - Export Sensitive Data anaylsis
 "si_lifecycle"              - Export SoftwareInstance lifecycle report
 "si_user_accounts"          - Software with running process usernames
-"suggest_cred_opt"          - Display suggested order of credentials based on restricted ips, excluded ips, success/failure, privilege, type
+"suggested_cred_opt"        - Display suggested order of credentials based on restricted ips, excluded ips, success/failure, privilege, type
 "tku"                       - TKU version summary
 "unrecognised_snmp"         - Report of unrecognised SNMP devices (Model > Device)
 "capture_candidates" - Report of capture candidates
@@ -626,7 +626,7 @@ if args.access_method=="api":
     if args.excavate and args.excavate[0] == "devices_with_cred":
         builder.get_credential(search, creds, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "suggest_cred_opt"):
+    if excavate_default or (args.excavate and args.excavate[0] == "suggested_cred_opt"):
         builder.ordering(creds, search, args, False)
 
     if args.a_query:

--- a/merge_outputs.py
+++ b/merge_outputs.py
@@ -12,7 +12,7 @@ EXPECTED_REPORTS = OrderedDict([
     ("discovery_analysis", "Discovery analysis summary"),
     ("devices_with_cred", "Devices with associated credentials"),
     ("device", "Individual device information"),
-    ("suggest_cred_opt", "Suggested credential optimization"),
+    ("suggested_cred_opt", "Suggested credential optimization"),
     ("schedules", "Discovery schedules"),
     ("overlapping_ips", "Overlapping IP ranges"),
 ])

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -64,11 +64,12 @@ def test_ordering_inserts_instance_and_outpost(monkeypatch):
     )
 
     creds = types.SimpleNamespace(update_cred=lambda *a, **k: None, get_vault_credentials=None)
-    args = types.SimpleNamespace(output_csv=False, output_file=None, target="appl", token=None, f_token=None, excavate=["suggest_cred_opt"])
+    args = types.SimpleNamespace(output_csv=False, output_file=None, target="appl", token=None, f_token=None, excavate=["suggested_cred_opt"])
 
     builder.ordering(creds, DummySearch(), args, False)
 
-    assert captured["name"] == "suggest_cred_opt"
+    # Verify the new key is propagated through the report
+    assert captured["name"] == "suggested_cred_opt"
     assert captured["headers"][0] == "Discovery Instance"
     assert "Scope" in captured["headers"]
     assert "OutpostUrl" in captured["headers"]


### PR DESCRIPTION
## Summary
- rename `suggest_cred_opt` references to `suggested_cred_opt`
- wire CLI excavation option to new name
- update merge helper and tests for new key

## Testing
- `python3 -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_capture_candidates_writes_csv, test_device_capture_candidates_defaults_sysobjectid, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type)*

------
https://chatgpt.com/codex/tasks/task_e_68a595c262408326a834400a95e54a7a