### PR TITLE
chore: clarify expected report descriptions

### DIFF
--- a/merge_outputs.py
+++ b/merge_outputs.py
@@ -6,13 +6,13 @@ import pandas as pd
 
 # Expected reports mapping in insertion order
 EXPECTED_REPORTS = OrderedDict([
-    ("credential_success", "Credential success and failure summary"),
-    ("device_ids", "List of unique device identities"),
-    ("devices", "Device details"),
-    ("discovery_analysis", "Discovery analysis summary"),
+    ("credential_success", "Summary of credential successes and failures"),
+    ("device_ids", "List of unique device identifiers"),
+    ("devices", "Detailed device information"),
+    ("discovery_analysis", "Summary of discovery analysis results"),
     ("devices_with_cred", "Devices with associated credentials"),
-    ("device", "Individual device information"),
-    ("suggest_cred_opt", "Suggested credential optimization"),
+    ("device", "Information for individual devices"),
+    ("suggest_cred_opt", "Suggested credential optimizations"),
     ("schedules", "Discovery schedules"),
     ("overlapping_ips", "Overlapping IP ranges"),
 ])


### PR DESCRIPTION
## Summary
- polish the EXPECTED_REPORTS descriptions in merge_outputs

## Testing
- `python3 -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_capture_candidates_writes_csv, test_device_capture_candidates_defaults_sysobjectid, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type)*


------
https://chatgpt.com/codex/tasks/task_e_68a595c846708326889a1dfb3db18938