### PR TITLE
Add discovery instance column to capture candidate CSV

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -662,14 +662,14 @@ def capture_candidates(search, args, dir):
     count = len(results) if isinstance(results, list) else 0
     tools.completage("Processing", count or 1, (count or 1) - 1)
     print(os.linesep, end="\r")
-    header, rows, header_hf = [], [], []
+    header, rows = [], []
     if isinstance(results, list) and results:
-        header, rows, header_hf = tools.json2csv(results)
-        header_hf.insert(0, "Discovery Instance")
+        header, rows, _ = tools.json2csv(results)
         for row in rows:
             row.insert(0, args.target)
-    else:
-        header.insert(0, "Discovery Instance")
+            # Replace ``None`` values with "N/A" for readability
+            row[1:] = [value if value is not None else "N/A" for value in row[1:]]
+    header.insert(0, "Discovery Instance")
     csv_header = tools.normalize_keys(header)
     output.define_csv(
         args,


### PR DESCRIPTION
## Summary
- Insert discovery instance column into capture_candidates CSV header
- Normalize headers and replace missing values with `N/A`

## Testing
- `python3 -m pytest tests/test_api.py::test_capture_candidates_writes_csv -q`


------
https://chatgpt.com/codex/tasks/task_e_68a595d960b88326867877b014cd615c