### PR TITLE
feat: support YAML config and multi-appliance runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,41 @@ The options `-P`, `-T` and `-W` can be used to read the UI password, API token a
 By default, reports are saved to an `output_<appliance>` directory in the current working directory.
 Use the `--stdout` option to suppress file output and print results directly to the terminal.
 
+### YAML configuration
+
+Default arguments can be supplied in a YAML file.  By default `dismal.py`
+looks for `config.yaml` in the current working directory.  A different file
+may be provided with `--config <file>`.  Values from the YAML are used as the
+defaults for command-line options, but any flags supplied on the CLI take
+precedence.
+
+The file may also contain an `appliances` list to run the same command against
+multiple Discovery targets with individual credentials.
+
+Example `config.yaml`:
+
+```yaml
+access_method: api
+username: admin
+password: secret
+noping: true
+appliances:
+  - target: appliance1.example.com
+    username: alice
+    password: alicepass
+  - target: appliance2.example.com
+    token: ABCDEF123456
+```
+
+Run the tool using the configuration:
+
+```bash
+python3 dismal.py --config config.yaml --sysadmin audit
+```
+
+CLI flags override YAML values, so `--access_method cli` on the command line
+would replace any `access_method` defined in the file.
+
 ### Endpoint filtering
 
 Device-centric reports can now be limited to a subset of endpoints.  Supplying

--- a/dismal.py
+++ b/dismal.py
@@ -12,6 +12,7 @@ import logging
 import time
 import os
 import sys
+import yaml
 from argparse import RawTextHelpFormatter
 
 from core import access, api, builder, cli, curl, output, reporting, tools
@@ -21,8 +22,23 @@ logfile = 'dismal_%s.log'%( str(datetime.date.today() ))
 argv = sys.argv[1:]
 pwd  = os.getcwd()
 
-parser = argparse.ArgumentParser(description='DisMAL Toolkit for BMC Discovery v%s'%vers,formatter_class=RawTextHelpFormatter)
+# Pre-parse config file option so YAML values can supply defaults
+config_parser = argparse.ArgumentParser(add_help=False)
+config_parser.add_argument('--config', dest='config', type=str, help='Path to YAML config file.')
+config_args, remaining_argv = config_parser.parse_known_args(argv)
+
+config_file = config_args.config or os.path.join(pwd, 'config.yaml')
+config = {}
+if os.path.exists(config_file):
+    with open(config_file, 'r') as cf:
+        config = yaml.safe_load(cf) or {}
+
+parser = argparse.ArgumentParser(
+    description='DisMAL Toolkit for BMC Discovery v%s'%vers,
+    formatter_class=RawTextHelpFormatter,
+)
 parser.add_argument('-v', '--version', dest='version', action='store_true', required=False, help='Version info for this app.\n\n')
+parser.add_argument('--config', dest='config', type=str, required=False, help='Path to YAML config file.')
 
 # Access Inputs
 access_inputs = parser.add_argument_group("Discovery Target Access Methods")
@@ -30,8 +46,8 @@ access_inputs.add_argument('-a','--access_method', dest='access_method', choices
 Method to get data:
 "api" - Use API commands only.
 "cli" - Use CLI commands only.
-"all" - Use API and CLI commands (default).
-\n''',default='all',metavar='<method>')
+"all" - Use API and CLI commands.
+\n''',metavar='<method>')
 access_inputs.add_argument('-i','--discovery_instance', dest='target',  type=str, required=False, help='The Discovery or Outpost target.\n\n', metavar='<ip_or_hostname>')
 access_inputs.add_argument('-u','--username',           dest='username',  type=str, required=False, help='A login username for Discovery.\n\n',metavar='<username>')
 access_inputs.add_argument('-p','--password',           dest='password',  type=str, required=False, help='The login password for Discovery.\n\n',metavar='<password>')
@@ -177,550 +193,574 @@ excavation.add_argument(
     metavar='<prefix>',
 )
 
+# Apply configuration defaults before final parsing so CLI overrides them
+parser.set_defaults(
+    access_method=config.get('access_method', 'all'),
+    target=config.get('target'),
+    username=config.get('username'),
+    password=config.get('password'),
+    token=config.get('token'),
+    noping=config.get('noping', False),
+    debugging=config.get('debugging', False),
+)
+
 global args
-args = parser.parse_args()
-start_time = time.time()
+args = parser.parse_args(remaining_argv)
 
-# Detect if --excavate was provided with no report or with 'default'
-excavate_default = False
-if args.excavate is not None:
-    if len(args.excavate) == 0 or args.excavate[0] == "default":
-        excavate_default = True
+def run_for_args(args):
+    start_time = time.time()
 
-if args.version:
-    print(vers)
-    if not args.target:
-        sys.exit(0)
+    # Detect if --excavate was provided with no report or with 'default'
+    excavate_default = False
+    if args.excavate is not None:
+        if len(args.excavate) == 0 or args.excavate[0] == "default":
+            excavate_default = True
 
-if args.wakey:
-    if not tools.in_wsl():
-        # pyautogui can't run in WSL as there is no screen, but need to keep function for Linux desktop
-        import pyautogui
-        print("Press CTRL+C to exit.")
-        while True:
-            pyautogui.moveRel(5,0, duration=0)
-            pyautogui.moveRel(-5,0, duration=0)
-            pyautogui.press('shift')
-            pyautogui.PAUSE = 60
+    if args.version:
+        print(vers)
+        if not args.target:
+            sys.exit(0)
 
-if args.target:
-    if args.output_path:
-        reporting_dir = args.output_path + "/output_" + args.target.replace(".","_")
-    else:
-        reporting_dir = pwd + "/output_" + args.target.replace(".","_")
-    if not os.path.exists(reporting_dir):
-        os.makedirs(reporting_dir)
-    args.reporting_dir = reporting_dir
+    if args.wakey:
+        if not tools.in_wsl():
+            # pyautogui can't run in WSL as there is no screen, but need to keep function for Linux desktop
+            import pyautogui
+            print("Press CTRL+C to exit.")
+            while True:
+                pyautogui.moveRel(5,0, duration=0)
+                pyautogui.moveRel(-5,0, duration=0)
+                pyautogui.press('shift')
+                pyautogui.PAUSE = 60
 
-logging.basicConfig(level=logging.INFO, filename=logfile, filemode='w', force=True)
-logger = logging.getLogger("_dismal_")
-if args.debugging:
-    logging.getLogger().setLevel(logging.DEBUG)
-    logger.setLevel(logging.DEBUG)
-
-logger.info("DisMAL Version %s"%vers)
-
-if args.noping:
-    msg = "Ping check off for %s..."%args.target
-    print(msg)
-else:
     if args.target:
-        exit_code = access.ping(args.target)
-        if exit_code == 0:
-            msg = "%s: successful ping!"%args.target
-            print(msg)
-            logger.info(msg)
+        if args.output_path:
+            reporting_dir = args.output_path + "/output_" + args.target.replace(".","_")
         else:
-            msg = "%s not found (ping)\nExit code: %s"%(args.target, exit_code)
-            print(msg)
-            logger.critical(msg)
-            sys.exit(1)
-
-# Validate access methods
-api_target = None
-cli_target = None
-## API
-if args.access_method=="api":
-    api_target = access.api_target(args)
-    disco, search, creds, vault, knowledge = api.init_endpoints(api_target, args)
-    system_user, system_passwd = access.login_target(None, args)
-
-## Client
-if args.access_method=="cli":
-    cli_target, tw_passwd = access.cli_target(args)
-    ## System User Access
-    system_user, system_passwd = access.login_target(cli_target, args)
-
-## All
-if args.access_method=="all":
-    api_target = access.api_target(args)
-    disco, search, creds, vault, knowledge = api.init_endpoints(api_target, args)
-    cli_target, tw_passwd = access.cli_target(args)
-    system_user, system_passwd = access.login_target(cli_target, args)
-
-if args.access_method == "all":
-
-    curl_cmd = True
-
-    if cli_target:
-
-        cli.certificates(cli_target, args, reporting_dir)
-        cli.etc_passwd(cli_target, args, reporting_dir)
-        cli.cluster_info(cli_target, args, reporting_dir)
-        cli.cmdb_errors(cli_target, args, reporting_dir)
-        cli.core_dumps(cli_target, args, reporting_dir)
-        cli.df_h(cli_target, args, reporting_dir)
-        cli.resolv_conf(cli_target, args, reporting_dir)
-        cli.ds_compact(cli_target, args, reporting_dir)
-        cli.host_info(cli_target, args, reporting_dir)
-        cli.ldap(cli_target, args, reporting_dir)
-        cli.timedatectl(cli_target, args, reporting_dir)
-        cli.reasoning(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.reports_model(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.syslog(cli_target, args, tw_passwd, reporting_dir)
-        cli.tax_deprecated(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.tree(cli_target, args, reporting_dir)
-        cli.tw_config_dump(cli_target, args, reporting_dir)
-        cli.tw_crontab(cli_target, args, reporting_dir)
-        cli.tw_options(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.ui_errors(cli_target, args, reporting_dir)
-        cli.vmware_tools(cli_target, args, tw_passwd, reporting_dir)
-        cli.audit(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.baseline(cli_target, args, reporting_dir)
-        cli.cmdb_sync(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.tw_events(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.export_platforms(cli_target, args, system_user, system_passwd, reporting_dir)
-        curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
-        curl_cmd = False
-        cli.knowledge(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.licensing(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.tw_list_users(cli_target, args, reporting_dir)
-        reporting.successful_cli(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.schedules(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.excludes(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.sensitive(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.tplexport(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.eca_errors(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.open_ports(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.host_util(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.orphan_vms(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.missing_vms(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.near_removal(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.removed(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.os_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.software_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.db_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.unrecognised_snmp(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.capture_candidates(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
-        cli.module_summary(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if api_target:
-
-        api.admin(disco, args, reporting_dir)
-        api.audit(search, args, reporting_dir)
-        api.baseline(disco, args, reporting_dir)
-        api.cmdb_config(search, args, reporting_dir)
-        if curl_cmd:
-            curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
-        api.modules(search, args, reporting_dir)
-        api.licensing(search, args, reporting_dir)     
-        reporting.devices(search, creds, args)
-        builder.ordering(creds, search, args, False)
-        api.success(creds, search, args, reporting_dir)
-        builder.scheduling(creds, search, args)
-        api.excludes(search, args, reporting_dir)
-        builder.ip_analysis(search, args)
-        reporting.discovery_analysis(search, creds, args)
-        api.show_runs(disco, args)
-        api.discovery_runs(disco, args, reporting_dir)
-        api.tpl_export(search, args, reporting_dir)
-        api.eca_errors(search, args, reporting_dir)
-        api.open_ports(search, args, reporting_dir)
-        api.host_util(search, args, reporting_dir)
-        api.orphan_vms(search, args, reporting_dir)
-        api.missing_vms(search, args, reporting_dir)
-        api.near_removal(search, args, reporting_dir)
-        api.removed(search, args, reporting_dir)
-        api.snmp(search, args, reporting_dir)
-        api.capture_candidates(search, args, reporting_dir)
-        api.oslc(search, args, reporting_dir)
-        api.slc(search, args, reporting_dir)
-        api.dblc(search, args, reporting_dir)
-        api.agents(search, args, reporting_dir)
-        api.software_users(search, args, reporting_dir)
-        api.tku(knowledge, args, reporting_dir)
-
-if args.access_method=="cli":
-
-    if args.tideway == "certificates":
-        cli.certificates(cli_target, args, reporting_dir)
-
-    if args.tideway == "cli_users":
-        cli.etc_passwd(cli_target, args, reporting_dir)
-
-    if args.tideway == "clustering":
-        cli.cluster_info(cli_target, args, reporting_dir)
-
-    if args.tideway == "cmdb_errors":
-        cli.cmdb_errors(cli_target, args, reporting_dir)
-
-    if args.tideway == "core_dumps":
-        cli.core_dumps(cli_target, args, reporting_dir)
-
-    if args.tideway == "disk_info":
-        cli.df_h(cli_target, args, reporting_dir)
-
-    if args.tideway == "dns_resolution":
-        cli.resolv_conf(cli_target, args, reporting_dir)
-
-    if args.tideway == "ds_status":
-        cli.ds_compact(cli_target, args, reporting_dir)
-
-    if args.tideway == "host_info":
-        cli.host_info(cli_target, args, reporting_dir)
-
-    if args.tideway == "ldap":
-        cli.ldap(cli_target, args, reporting_dir)
-
-    if args.tideway == "ntp":
-        cli.timedatectl(cli_target, args, reporting_dir)
-
-    if args.tideway == "reasoning":
-        cli.reasoning(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.tideway == "reports_model":
-        cli.reports_model(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.tideway == "syslog":
-        cli.syslog(cli_target, args, tw_passwd, reporting_dir)
-
-    if args.tideway == "tax_deprecated":
-        cli.tax_deprecated(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.tideway == "tree":
-        cli.tree(cli_target, args, reporting_dir)
-
-    if args.tideway == "tw_config_dump":
-        cli.tw_config_dump(cli_target, args, reporting_dir)
-
-    if args.tideway == "tw_crontab":
-        cli.tw_crontab(cli_target, args, reporting_dir)
-
-    if args.tideway == "tw_options":
-        cli.tw_options(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.tideway == "ui_errors":
-        cli.ui_errors(cli_target, args, reporting_dir)
-
-    if args.tideway == "vmware_tools":
-        cli.vmware_tools(cli_target, args, tw_passwd, reporting_dir)
-
-    if args.clear_queue:
-        cli.clear_queue(cli_target)
-
-    if args.tw_user:
-        cli.user_management(cli_target, args)
-
-    if args.servicecctl:
-        cli.service_management(cli_target, args)
-
-    if args.sysadmin == "audit":
-        cli.audit(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.sysadmin == "baseline":
-        cli.baseline(cli_target, args, reporting_dir)
-
-    if args.sysadmin == "cmdbsync":
-        cli.cmdb_sync(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.sysadmin == "events":
-        cli.tw_events(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.sysadmin == "platforms":
-        cli.export_platforms(cli_target, args, system_user, system_passwd, reporting_dir)
-        curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
-
-    if args.sysadmin == "knowledge":
-        cli.knowledge(cli_target, args, system_user, system_passwd, reporting_dir)
-    
-    if args.sysadmin == "licensing":
-        cli.licensing(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if args.sysadmin == "users":
-        cli.tw_list_users(cli_target, args, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "credential_success"):
-        reporting.successful_cli(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "schedules"):
-        cli.schedules(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "excludes"):
-        cli.excludes(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "sensitive_data"):
-        cli.sensitive(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "export_tpl"):
-        cli.tplexport(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "eca_errors"):
-        cli.eca_errors(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "open_ports"):
-        cli.open_ports(cli_target, args, system_user, system_passwd, reporting_dir)
-    
-    if excavate_default or (args.excavate and args.excavate[0] == "host_utilisation"):
-        cli.host_util(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "orphan_vms"):
-        cli.orphan_vms(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "missing_vms"):
-        cli.missing_vms(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "near_removal"):
-        cli.near_removal(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "removed"):
-        cli.removed(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "os_lifecycle"):
-        cli.os_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "software_lifecycle"):
-        cli.software_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "db_lifecycle"):
-        cli.db_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "unrecogised_snmp"):
-        cli.unrecognised_snmp(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "capture_candidates"):
-        cli.capture_candidates(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
-        cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
-        cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
-
-    if excavate_default or (args.excavate and args.excavate[0] == "pattern_modules"):
-        cli.module_summary(cli_target, args, system_user, system_passwd, reporting_dir)
-
-if args.access_method=="api":
-
-    if args.sysadmin == "api_version":
-        api.admin(disco, args, reporting_dir)
-
-    if args.sysadmin == "audit":
-        api.audit(search, args, reporting_dir)
-
-    if args.sysadmin == "baseline":
-        api.baseline(disco, args, reporting_dir)
-
-    if args.sysadmin == "cmdbsync":
-        api.cmdb_config(search, args, reporting_dir)
-
-    if args.sysadmin == "platforms":
-        curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
-
-    if args.sysadmin == "knowledge":
-        api.modules(search, args, reporting_dir)
-
-    if args.sysadmin == "licensing":
-        api.licensing(search, args, reporting_dir)
-
-    if args.a_enable:
-        active = api.update_cred(creds, args.a_enable)
-        if active is not None:
-            if active:
-                msg = "Credential %s Activated.\n" % (args.a_enable)
-            else:
-                msg = "Credential %s Deactivated.\n" % (args.a_enable)
-        else:
-            msg = "Unable to determine %s credential state.\n" % (args.a_enable)
+            reporting_dir = pwd + "/output_" + args.target.replace(".","_")
+        if not os.path.exists(reporting_dir):
+            os.makedirs(reporting_dir)
+        args.reporting_dir = reporting_dir
+
+    logging.basicConfig(level=logging.INFO, filename=logfile, filemode='w', force=True)
+    logger = logging.getLogger("_dismal_")
+    if args.debugging:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
+
+    logger.info("DisMAL Version %s"%vers)
+
+    if args.noping:
+        msg = "Ping check off for %s..."%args.target
         print(msg)
-        logger.info(msg)
-
-    if args.f_enablelist:
-        exists = os.path.isfile(args.f_enablelist)
-        if exists:
-            go_ahead = input("This will switch the 'enabled' status of all credentials\nEnabled -> Disabled\nDisabled -> Enabled\n\nContinue? (Y/y) ")
-            if go_ahead == "y" or go_ahead == "Y":
-                with open(args.f_enablelist) as f:
-                    for line in f:
-                        active = api.update_cred(creds, line.strip())
-                        if active is not None:
-                            if active:
-                                msg = "Credential %s Activated.\n" % (line.strip())
-                            else:
-                                msg = "Credential %s Deactivated.\n" % (line.strip())
-                        else:
-                            msg = "Unable to determine %s credential state.\n" % (line.strip())
-                        logger.info(msg)
-
-    if args.a_opt:
-        builder.ordering(creds, search, args, True)
-
-    if args.a_removal:
-        lookup = builder.get_credential(search, creds, args.a_removal, args)
-        if lookup:
-            go_ahead = input("Are you sure you want to delete this credential? (Y/y) ")
-            if go_ahead == "y" or go_ahead == "Y":
-                success = api.remove_cred(creds, args)
-                if success:
-                    msg = "Credential %s deleted from %s." % (args.a_removal, args.target)
-                else:
-                    msg = "Credential %s was not deleted\n%s" % (args.a_removal, success)
+    else:
+        if args.target:
+            exit_code = access.ping(args.target)
+            if exit_code == 0:
+                msg = "%s: successful ping!"%args.target
                 print(msg)
                 logger.info(msg)
+            else:
+                msg = "%s not found (ping)\nExit code: %s"%(args.target, exit_code)
+                print(msg)
+                logger.critical(msg)
+                sys.exit(1)
 
-    if args.f_remlist:
-        exists = os.path.isfile(args.f_remlist)
-        if exists:
-            with open(args.f_remlist) as f:
-                for line in f:
-                    success = api.remove_cred(creds, line.strip())
+    # Validate access methods
+    api_target = None
+    cli_target = None
+    ## API
+    if args.access_method=="api":
+        api_target = access.api_target(args)
+        disco, search, creds, vault, knowledge = api.init_endpoints(api_target, args)
+        system_user, system_passwd = access.login_target(None, args)
+
+    ## Client
+    if args.access_method=="cli":
+        cli_target, tw_passwd = access.cli_target(args)
+        ## System User Access
+        system_user, system_passwd = access.login_target(cli_target, args)
+
+    ## All
+    if args.access_method=="all":
+        api_target = access.api_target(args)
+        disco, search, creds, vault, knowledge = api.init_endpoints(api_target, args)
+        cli_target, tw_passwd = access.cli_target(args)
+        system_user, system_passwd = access.login_target(cli_target, args)
+
+    if args.access_method == "all":
+
+        curl_cmd = True
+
+        if cli_target:
+
+            cli.certificates(cli_target, args, reporting_dir)
+            cli.etc_passwd(cli_target, args, reporting_dir)
+            cli.cluster_info(cli_target, args, reporting_dir)
+            cli.cmdb_errors(cli_target, args, reporting_dir)
+            cli.core_dumps(cli_target, args, reporting_dir)
+            cli.df_h(cli_target, args, reporting_dir)
+            cli.resolv_conf(cli_target, args, reporting_dir)
+            cli.ds_compact(cli_target, args, reporting_dir)
+            cli.host_info(cli_target, args, reporting_dir)
+            cli.ldap(cli_target, args, reporting_dir)
+            cli.timedatectl(cli_target, args, reporting_dir)
+            cli.reasoning(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.reports_model(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.syslog(cli_target, args, tw_passwd, reporting_dir)
+            cli.tax_deprecated(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.tree(cli_target, args, reporting_dir)
+            cli.tw_config_dump(cli_target, args, reporting_dir)
+            cli.tw_crontab(cli_target, args, reporting_dir)
+            cli.tw_options(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.ui_errors(cli_target, args, reporting_dir)
+            cli.vmware_tools(cli_target, args, tw_passwd, reporting_dir)
+            cli.audit(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.baseline(cli_target, args, reporting_dir)
+            cli.cmdb_sync(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.tw_events(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.export_platforms(cli_target, args, system_user, system_passwd, reporting_dir)
+            curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
+            curl_cmd = False
+            cli.knowledge(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.licensing(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.tw_list_users(cli_target, args, reporting_dir)
+            reporting.successful_cli(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.schedules(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.excludes(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.sensitive(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.tplexport(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.eca_errors(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.open_ports(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.host_util(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.orphan_vms(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.missing_vms(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.near_removal(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.removed(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.os_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.software_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.db_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.unrecognised_snmp(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.capture_candidates(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.module_summary(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if api_target:
+
+            api.admin(disco, args, reporting_dir)
+            api.audit(search, args, reporting_dir)
+            api.baseline(disco, args, reporting_dir)
+            api.cmdb_config(search, args, reporting_dir)
+            if curl_cmd:
+                curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
+            api.modules(search, args, reporting_dir)
+            api.licensing(search, args, reporting_dir)     
+            reporting.devices(search, creds, args)
+            builder.ordering(creds, search, args, False)
+            api.success(creds, search, args, reporting_dir)
+            builder.scheduling(creds, search, args)
+            api.excludes(search, args, reporting_dir)
+            builder.ip_analysis(search, args)
+            reporting.discovery_analysis(search, creds, args)
+            api.show_runs(disco, args)
+            api.discovery_runs(disco, args, reporting_dir)
+            api.tpl_export(search, args, reporting_dir)
+            api.eca_errors(search, args, reporting_dir)
+            api.open_ports(search, args, reporting_dir)
+            api.host_util(search, args, reporting_dir)
+            api.orphan_vms(search, args, reporting_dir)
+            api.missing_vms(search, args, reporting_dir)
+            api.near_removal(search, args, reporting_dir)
+            api.removed(search, args, reporting_dir)
+            api.snmp(search, args, reporting_dir)
+            api.capture_candidates(search, args, reporting_dir)
+            api.oslc(search, args, reporting_dir)
+            api.slc(search, args, reporting_dir)
+            api.dblc(search, args, reporting_dir)
+            api.agents(search, args, reporting_dir)
+            api.software_users(search, args, reporting_dir)
+            api.tku(knowledge, args, reporting_dir)
+
+    if args.access_method=="cli":
+
+        if args.tideway == "certificates":
+            cli.certificates(cli_target, args, reporting_dir)
+
+        if args.tideway == "cli_users":
+            cli.etc_passwd(cli_target, args, reporting_dir)
+
+        if args.tideway == "clustering":
+            cli.cluster_info(cli_target, args, reporting_dir)
+
+        if args.tideway == "cmdb_errors":
+            cli.cmdb_errors(cli_target, args, reporting_dir)
+
+        if args.tideway == "core_dumps":
+            cli.core_dumps(cli_target, args, reporting_dir)
+
+        if args.tideway == "disk_info":
+            cli.df_h(cli_target, args, reporting_dir)
+
+        if args.tideway == "dns_resolution":
+            cli.resolv_conf(cli_target, args, reporting_dir)
+
+        if args.tideway == "ds_status":
+            cli.ds_compact(cli_target, args, reporting_dir)
+
+        if args.tideway == "host_info":
+            cli.host_info(cli_target, args, reporting_dir)
+
+        if args.tideway == "ldap":
+            cli.ldap(cli_target, args, reporting_dir)
+
+        if args.tideway == "ntp":
+            cli.timedatectl(cli_target, args, reporting_dir)
+
+        if args.tideway == "reasoning":
+            cli.reasoning(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.tideway == "reports_model":
+            cli.reports_model(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.tideway == "syslog":
+            cli.syslog(cli_target, args, tw_passwd, reporting_dir)
+
+        if args.tideway == "tax_deprecated":
+            cli.tax_deprecated(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.tideway == "tree":
+            cli.tree(cli_target, args, reporting_dir)
+
+        if args.tideway == "tw_config_dump":
+            cli.tw_config_dump(cli_target, args, reporting_dir)
+
+        if args.tideway == "tw_crontab":
+            cli.tw_crontab(cli_target, args, reporting_dir)
+
+        if args.tideway == "tw_options":
+            cli.tw_options(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.tideway == "ui_errors":
+            cli.ui_errors(cli_target, args, reporting_dir)
+
+        if args.tideway == "vmware_tools":
+            cli.vmware_tools(cli_target, args, tw_passwd, reporting_dir)
+
+        if args.clear_queue:
+            cli.clear_queue(cli_target)
+
+        if args.tw_user:
+            cli.user_management(cli_target, args)
+
+        if args.servicecctl:
+            cli.service_management(cli_target, args)
+
+        if args.sysadmin == "audit":
+            cli.audit(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.sysadmin == "baseline":
+            cli.baseline(cli_target, args, reporting_dir)
+
+        if args.sysadmin == "cmdbsync":
+            cli.cmdb_sync(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.sysadmin == "events":
+            cli.tw_events(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.sysadmin == "platforms":
+            cli.export_platforms(cli_target, args, system_user, system_passwd, reporting_dir)
+            curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
+
+        if args.sysadmin == "knowledge":
+            cli.knowledge(cli_target, args, system_user, system_passwd, reporting_dir)
+    
+        if args.sysadmin == "licensing":
+            cli.licensing(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if args.sysadmin == "users":
+            cli.tw_list_users(cli_target, args, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "credential_success"):
+            reporting.successful_cli(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "schedules"):
+            cli.schedules(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "excludes"):
+            cli.excludes(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "sensitive_data"):
+            cli.sensitive(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "export_tpl"):
+            cli.tplexport(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "eca_errors"):
+            cli.eca_errors(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "open_ports"):
+            cli.open_ports(cli_target, args, system_user, system_passwd, reporting_dir)
+    
+        if excavate_default or (args.excavate and args.excavate[0] == "host_utilisation"):
+            cli.host_util(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "orphan_vms"):
+            cli.orphan_vms(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "missing_vms"):
+            cli.missing_vms(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "near_removal"):
+            cli.near_removal(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "removed"):
+            cli.removed(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "os_lifecycle"):
+            cli.os_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "software_lifecycle"):
+            cli.software_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "db_lifecycle"):
+            cli.db_lifecycle(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "unrecogised_snmp"):
+            cli.unrecognised_snmp(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "capture_candidates"):
+            cli.capture_candidates(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
+            cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
+            cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "pattern_modules"):
+            cli.module_summary(cli_target, args, system_user, system_passwd, reporting_dir)
+
+    if args.access_method=="api":
+
+        if args.sysadmin == "api_version":
+            api.admin(disco, args, reporting_dir)
+
+        if args.sysadmin == "audit":
+            api.audit(search, args, reporting_dir)
+
+        if args.sysadmin == "baseline":
+            api.baseline(disco, args, reporting_dir)
+
+        if args.sysadmin == "cmdbsync":
+            api.cmdb_config(search, args, reporting_dir)
+
+        if args.sysadmin == "platforms":
+            curl.platform_scripts(args, system_user, system_passwd, reporting_dir+"/platforms")
+
+        if args.sysadmin == "knowledge":
+            api.modules(search, args, reporting_dir)
+
+        if args.sysadmin == "licensing":
+            api.licensing(search, args, reporting_dir)
+
+        if args.a_enable:
+            active = api.update_cred(creds, args.a_enable)
+            if active is not None:
+                if active:
+                    msg = "Credential %s Activated.\n" % (args.a_enable)
+                else:
+                    msg = "Credential %s Deactivated.\n" % (args.a_enable)
+            else:
+                msg = "Unable to determine %s credential state.\n" % (args.a_enable)
+            print(msg)
+            logger.info(msg)
+
+        if args.f_enablelist:
+            exists = os.path.isfile(args.f_enablelist)
+            if exists:
+                go_ahead = input("This will switch the 'enabled' status of all credentials\nEnabled -> Disabled\nDisabled -> Enabled\n\nContinue? (Y/y) ")
+                if go_ahead == "y" or go_ahead == "Y":
+                    with open(args.f_enablelist) as f:
+                        for line in f:
+                            active = api.update_cred(creds, line.strip())
+                            if active is not None:
+                                if active:
+                                    msg = "Credential %s Activated.\n" % (line.strip())
+                                else:
+                                    msg = "Credential %s Deactivated.\n" % (line.strip())
+                            else:
+                                msg = "Unable to determine %s credential state.\n" % (line.strip())
+                            logger.info(msg)
+
+        if args.a_opt:
+            builder.ordering(creds, search, args, True)
+
+        if args.a_removal:
+            lookup = builder.get_credential(search, creds, args.a_removal, args)
+            if lookup:
+                go_ahead = input("Are you sure you want to delete this credential? (Y/y) ")
+                if go_ahead == "y" or go_ahead == "Y":
+                    success = api.remove_cred(creds, args)
                     if success:
-                        msg = "Credential %s deleted from %s." % (line.strip(), args.target)
+                        msg = "Credential %s deleted from %s." % (args.a_removal, args.target)
                     else:
-                        msg = "Credential %s was not deleted\n%s" % (line.strip(), success)
+                        msg = "Credential %s was not deleted\n%s" % (args.a_removal, success)
+                    print(msg)
                     logger.info(msg)
+
+        if args.f_remlist:
+            exists = os.path.isfile(args.f_remlist)
+            if exists:
+                with open(args.f_remlist) as f:
+                    for line in f:
+                        success = api.remove_cred(creds, line.strip())
+                        if success:
+                            msg = "Credential %s deleted from %s." % (line.strip(), args.target)
+                        else:
+                            msg = "Credential %s was not deleted\n%s" % (line.strip(), success)
+                        logger.info(msg)
         
-    if args.a_kill_run:
-        api.cancel_run(disco, args)
+        if args.a_kill_run:
+            api.cancel_run(disco, args)
 
-    if args.schedule_timezone:
-        api.update_schedule_timezone(disco, args)
+        if args.schedule_timezone:
+            api.update_schedule_timezone(disco, args)
 
-    if args.excavate and args.excavate[0] == "device":
-        builder.get_device(search, creds, args)
+        if args.excavate and args.excavate[0] == "device":
+            builder.get_device(search, creds, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "devices"):
-        reporting.devices(search, creds, args)
+        if excavate_default or (args.excavate and args.excavate[0] == "devices"):
+            reporting.devices(search, creds, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "device_ids"):
-        identities = builder.unique_identities(search, args.include_endpoints, args.endpoint_prefix)
-        data = []
-        for identity in identities:
-            data.append([
-                identity['originating_endpoint'],
-                identity['list_of_ips'],
-                identity['list_of_names'],
-                identity.get('coverage_pct'),
-            ])
-        output.report(
-            data,
-            ["Origating Endpoint", "List of IPs", "List of Names", "Coverage %"],
-            args,
-            name="device_ids",
-        )
+        if excavate_default or (args.excavate and args.excavate[0] == "device_ids"):
+            identities = builder.unique_identities(search, args.include_endpoints, args.endpoint_prefix)
+            data = []
+            for identity in identities:
+                data.append([
+                    identity['originating_endpoint'],
+                    identity['list_of_ips'],
+                    identity['list_of_names'],
+                    identity.get('coverage_pct'),
+                ])
+            output.report(
+                data,
+                ["Origating Endpoint", "List of IPs", "List of Names", "Coverage %"],
+                args,
+                name="device_ids",
+            )
 
-    if args.excavate and args.excavate[0] == "ipaddr":
-        reporting.ipaddr(search, creds, args)
+        if args.excavate and args.excavate[0] == "ipaddr":
+            reporting.ipaddr(search, creds, args)
 
-    if args.excavate and args.excavate[0] == "devices_with_cred":
-        builder.get_credential(search, creds, args)
+        if args.excavate and args.excavate[0] == "devices_with_cred":
+            builder.get_credential(search, creds, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "suggested_cred_opt"):
-        builder.ordering(creds, search, args, False)
+        if excavate_default or (args.excavate and args.excavate[0] == "suggested_cred_opt"):
+            builder.ordering(creds, search, args, False)
 
-    if args.a_query:
-        api.query(search, args)
+        if args.a_query:
+            api.query(search, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "credential_success"):
-        api.success(creds, search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "credential_success"):
+            api.success(creds, search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "schedules"):
-        builder.scheduling(creds, search, args)
+        if excavate_default or (args.excavate and args.excavate[0] == "schedules"):
+            builder.scheduling(creds, search, args)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "excludes"):
-        api.excludes(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "excludes"):
+            api.excludes(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "ip_analysis"):
-        builder.ip_analysis(search, args)
+        if excavate_default or (args.excavate and args.excavate[0] == "ip_analysis"):
+            builder.ip_analysis(search, args)
 
-    # Gather discovery data and run analysis when requested.
-    if excavate_default or (args.excavate and args.excavate[0] == "discovery_analysis"):
-        disco_data = reporting._gather_discovery_data(search, creds, args)
-        reporting.discovery_analysis(search, creds, args, disco_data)
+        # Gather discovery data and run analysis when requested.
+        if excavate_default or (args.excavate and args.excavate[0] == "discovery_analysis"):
+            disco_data = reporting._gather_discovery_data(search, creds, args)
+            reporting.discovery_analysis(search, creds, args, disco_data)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "active_runs"):
-        api.show_runs(disco, args)
-        api.discovery_runs(disco, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "active_runs"):
+            api.show_runs(disco, args)
+            api.discovery_runs(disco, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "sensitive_data"):
-        api.sensitive(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "sensitive_data"):
+            api.sensitive(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "export_tpl"):
-        api.tpl_export(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "export_tpl"):
+            api.tpl_export(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "eca_errors"):
-        api.eca_errors(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "eca_errors"):
+            api.eca_errors(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "open_ports"):
-        api.open_ports(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "open_ports"):
+            api.open_ports(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "host_utilisation"):
-        api.host_util(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "host_utilisation"):
+            api.host_util(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "orphan_vms"):
-        api.orphan_vms(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "orphan_vms"):
+            api.orphan_vms(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "missing_vms"):
-        api.missing_vms(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "missing_vms"):
+            api.missing_vms(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "near_removal"):
-        api.near_removal(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "near_removal"):
+            api.near_removal(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "removed"):
-        api.removed(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "removed"):
+            api.removed(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "os_lifecycle"):
-        api.oslc(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "os_lifecycle"):
+            api.oslc(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "software_lifecycle"):
-        api.slc(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "software_lifecycle"):
+            api.slc(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "db_lifecycle"):
-        api.dblc(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "db_lifecycle"):
+            api.dblc(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "unrecogised_snmp"):
-        api.snmp(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "unrecogised_snmp"):
+            api.snmp(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "capture_candidates"):
-        api.capture_candidates(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "capture_candidates"):
+            api.capture_candidates(search, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
-        api.agents(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
+            api.agents(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
-        api.software_users(search, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
+            api.software_users(search, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "pattern_modules"):
-        #TODO: This report has been overlooked
-        api.tku(knowledge,args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "pattern_modules"):
+            #TODO: This report has been overlooked
+            api.tku(knowledge,args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "tku"):
-        api.tku(knowledge, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "tku"):
+            api.tku(knowledge, args, reporting_dir)
 
-    if excavate_default or (args.excavate and args.excavate[0] == "vault"):
-        api.vault(vault, args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "vault"):
+            api.vault(vault, args, reporting_dir)
     
-    if excavate_default or (args.excavate and args.excavate[0] == "hostname"):
-        api.hostname(args, reporting_dir)
+        if excavate_default or (args.excavate and args.excavate[0] == "hostname"):
+            api.hostname(args, reporting_dir)
 
-if cli_target:
-    cli_target.close()
+    if cli_target:
+        cli_target.close()
 
-elapsed = time.time() - start_time
-formatted = output.format_duration(elapsed)
-msg = f"Completed in {formatted}"
-print(msg)
-logger.info(msg)
+    elapsed = time.time() - start_time
+    formatted = output.format_duration(elapsed)
+    msg = f"Completed in {formatted}"
+    print(msg)
+    logger.info(msg)
 
-print(os.linesep)
+    print(os.linesep)
+
+appliance_list = config.get("appliances")
+if appliance_list and not args.target:
+    for appliance in appliance_list:
+        app_args = argparse.Namespace(**vars(args))
+        for key in ("target", "username", "password", "token"):
+            if key in appliance:
+                setattr(app_args, key, appliance[key])
+        run_for_args(app_args)
+else:
+    run_for_args(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tideway
 pyautogui
 tabulate
 cidrize
+PyYAML


### PR DESCRIPTION
## Summary
- load optional config.yaml before parsing CLI flags to set defaults
- iterate over `appliances` entries allowing per-appliance credentials
- document YAML configuration and add PyYAML dependency

## Testing
- `python3 -m pytest` *(fails: TypeError in fake_define_csv etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a59fb8a68483268b53acb51d758ec4