### PR TITLE
Add configuration template and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ output*/
 # Excel files
 *.xls
 *.xlsx
+
+# Local configuration
+config.yaml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ Use at your own risk.
 
    - pytest
 
+## Configuration
+
+A template configuration file is provided at `config.yaml.template`. Copy it to
+`config.yaml` and replace the placeholder values with your appliance details
+and credentials:
+
+```bash
+cp config.yaml.template config.yaml
+```
+
+Then edit `config.yaml` and set values for `appliances`, `token_file`,
+`username`, `password_file`, `access_method`, `noping`, and `debug`.
+
 ## Running the test suite
 
 Run all tests with:

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -1,0 +1,10 @@
+# DisMAL configuration template
+# Copy to config.yaml and replace placeholder values.
+appliances:
+  - <appliance_host>
+token_file: <path_to_token_file>
+username: <username>
+password_file: <path_to_password_file>
+access_method: <api_or_cli>
+noping: false
+debug: false


### PR DESCRIPTION
## Summary
- add `config.yaml.template` for common DisMAL settings
- ignore `config.yaml` so local config is not committed
- document how to use the configuration template in README

## Testing
- `python3 -m pytest` *(fails: 10 failed, 61 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a59fbb3a608326940522ea16983885