### PR TITLE
Add detailed appliance entries to config template

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -1,10 +1,15 @@
 # DisMAL configuration template
 # Copy to config.yaml and replace placeholder values.
 appliances:
-  - <appliance_host>
-token_file: <path_to_token_file>
-username: <username>
-password_file: <path_to_password_file>
+  - name: instance-prod
+    target: prod-host
+    token: <token>            # Optional: direct API token
+    token_file: <path>        # Optional: path to file containing API token
+    username: <username>      # Optional: username for CLI access
+    password: <password>      # Optional: password for CLI access
+  - name: instance-dev
+    target: dev-host
+    token_file: <path>        # Optional: path to file containing API token
 access_method: <api_or_cli>
 noping: false
 debug: false


### PR DESCRIPTION
## Summary
- replace simple host list with structured appliance entries in config template
- document optional authentication fields for each appliance

## Testing
- `python3 -m pytest` *(fails: TypeError: test_cli_orphan_vms_includes_os_type.<locals>.fake_save2csv() takes 3 positional arguments but 4 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a5409e80832688ba62c8ba218a64