### PR TITLE
Add default token and password file options

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -200,6 +200,8 @@ parser.set_defaults(
     username=config.get('username'),
     password=config.get('password'),
     token=config.get('token'),
+    f_token=config.get('token_file'),
+    f_passwd=config.get('password_file'),
     noping=config.get('noping', False),
     debugging=config.get('debugging', False),
 )


### PR DESCRIPTION
## Summary
- load token and password file paths from config into CLI parser defaults

## Testing
- `python3 -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_device_capture_candidates_defaults_sysobjectid, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a55102688326b1800366daa4e996