### PR TITLE
Support per-appliance credential overrides

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -754,13 +754,41 @@ def run_for_args(args):
 
     print(os.linesep)
 
-appliance_list = config.get("appliances")
-if appliance_list and not args.target:
-    for appliance in appliance_list:
-        app_args = argparse.Namespace(**vars(args))
-        for key in ("target", "username", "password", "token"):
-            if key in appliance:
-                setattr(app_args, key, appliance[key])
-        run_for_args(app_args)
-else:
-    run_for_args(args)
+
+def run_appliance_list(appliance_list, args):
+    """Run the tool for each appliance entry in a config list.
+
+    Each entry may be either a simple string representing the target host or
+    a dictionary providing credential overrides such as username/password,
+    token, or paths to token/password files.
+    """
+
+    if appliance_list and not args.target:
+        for appliance in appliance_list:
+            app_args = argparse.Namespace(**vars(args))
+
+            if isinstance(appliance, dict):
+                # Map config keys to CLI attribute names
+                key_map = {
+                    "target": "target",
+                    "username": "username",
+                    "password": "password",
+                    "token": "token",
+                    "token_file": "f_token",
+                    "password_file": "f_passwd",
+                }
+                for key, attr in key_map.items():
+                    if key in appliance:
+                        setattr(app_args, attr, appliance[key])
+            else:
+                # Treat string entries as target hostnames
+                app_args.target = appliance
+
+            run_for_args(app_args)
+    else:
+        run_for_args(args)
+
+
+if __name__ == "__main__":
+    appliance_list = config.get("appliances")
+    run_appliance_list(appliance_list, args)

--- a/tests/test_appliances.py
+++ b/tests/test_appliances.py
@@ -1,0 +1,44 @@
+import sys
+import types
+import argparse
+import importlib
+
+# Stub external dependencies before importing dismal
+sys.modules.setdefault("pandas", types.SimpleNamespace())
+sys.modules.setdefault("tabulate", types.SimpleNamespace(tabulate=lambda *a, **k: ""))
+sys.modules.setdefault("tideway", types.SimpleNamespace())
+sys.modules.setdefault("paramiko", types.SimpleNamespace())
+
+
+def test_run_appliance_list_handles_mixed_credentials(monkeypatch):
+    sys.argv = ["dismal"]
+    dismal = importlib.reload(importlib.import_module("dismal"))
+
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr(dismal, "run_for_args", fake_run)
+
+    base_args = argparse.Namespace(
+        target=None,
+        username="base",
+        password=None,
+        token=None,
+        f_token=None,
+        f_passwd=None,
+    )
+
+    appliance_list = [
+        {"target": "a1", "username": "u1", "token_file": "tok.txt"},
+        {"target": "a2", "username": "u2", "password_file": "pw.txt"},
+        "a3",
+    ]
+
+    dismal.run_appliance_list(appliance_list, base_args)
+
+    assert [c.target for c in calls] == ["a1", "a2", "a3"]
+    assert calls[0].f_token == "tok.txt"
+    assert calls[1].f_passwd == "pw.txt"
+    assert calls[2].username == "base"


### PR DESCRIPTION
## Summary
- allow `appliances` config entries to specify `token_file` and `password_file`
- handle simple host strings or dictionaries when iterating appliances
- test multiple appliance entries with mixed credential types

## Testing
- `python3 -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_device_capture_candidates_defaults_sysobjectid, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type)*
- `python3 -m pytest tests/test_appliances.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a55ee0e48326bcf65dcbd7b5b109