### PR TITLE
Add tests for config-driven appliance credentials

### DIFF
--- a/dismal.py
+++ b/dismal.py
@@ -754,13 +754,27 @@ def run_for_args(args):
 
     print(os.linesep)
 
-appliance_list = config.get("appliances")
-if appliance_list and not args.target:
-    for appliance in appliance_list:
-        app_args = argparse.Namespace(**vars(args))
-        for key in ("target", "username", "password", "token"):
-            if key in appliance:
-                setattr(app_args, key, appliance[key])
-        run_for_args(app_args)
-else:
-    run_for_args(args)
+
+def main():
+    appliance_list = config.get("appliances")
+    if appliance_list and not args.target:
+        for appliance in appliance_list:
+            app_args = argparse.Namespace(**vars(args))
+            for src, dest in (
+                ("target", "target"),
+                ("username", "username"),
+                ("password", "password"),
+                ("token", "token"),
+                ("token_file", "f_token"),
+                ("f_token", "f_token"),
+                ("password_file", "f_passwd"),
+            ):
+                if src in appliance:
+                    setattr(app_args, dest, appliance[src])
+            run_for_args(app_args)
+    else:
+        run_for_args(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+import yaml
+
+
+@pytest.fixture
+def multi_appliance_config(tmp_path):
+    """Create temporary config.yaml with two appliance entries."""
+    token_file = tmp_path / "token_file.txt"
+    token_file.write_text("file-token")
+
+    config = {
+        "appliances": [
+            {"target": "app1", "token": "tok1"},
+            {"target": "app2", "token_file": str(token_file), "password": "pw2"},
+        ]
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    return config_path, str(token_file)

--- a/tests/test_dismal_config.py
+++ b/tests/test_dismal_config.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+
+
+def test_dismal_iterates_over_config(monkeypatch, multi_appliance_config):
+    config_path, token_file_path = multi_appliance_config
+    # Ensure dismal loads our temporary config
+    monkeypatch.setattr(sys, "argv", ["dismal.py", "--config", str(config_path)])
+    dismal = importlib.reload(importlib.import_module("dismal"))
+
+    captured = []
+
+    def fake_run(args):
+        captured.append(args)
+
+    monkeypatch.setattr(dismal, "run_for_args", fake_run)
+    dismal.main()
+
+    assert len(captured) == 2
+
+    first, second = captured
+
+    assert first.target == "app1"
+    assert first.token == "tok1"
+    assert getattr(first, "f_token", None) is None
+    assert getattr(first, "password", None) is None
+
+    assert second.target == "app2"
+    assert second.token is None
+    assert second.f_token == token_file_path
+    assert second.password == "pw2"


### PR DESCRIPTION
## Summary
- handle token_file and password_file when iterating config appliances in dismal
- add fixture to build temporary multi-appliance config for tests
- add test ensuring dismal iterates over appliances with proper credentials

## Testing
- `python3 -m pytest tests/test_dismal_config.py -q`
- `python3 -m pytest` *(fails: test_show_runs_excavate_routes_to_define_csv, test_discovery_runs_emits_ints_and_camel_headers, test_device_capture_candidates_defaults_sysobjectid, test_ip_analysis_empty_excludes, test_ip_analysis_empty_scan_ranges, test_overlapping_unscanned_connections, test_prefers_named_and_updates_timestamp, test_picks_latest_when_no_names, test_api_orphan_vms_includes_os_type, test_cli_orphan_vms_includes_os_type)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a5624c088326a86a93b38b2515e6