### PR TITLE
Expose outpost credential details and merge into success report

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -952,6 +952,11 @@ def ip_analysis(tw_search, args):
 
     output.report(data, heads, args, name="ip_analysis")
 
+
+def overlapping(tw_search, args):
+    """Compatibility wrapper for legacy overlapping report."""
+    ip_analysis(tw_search, args)
+
 def get_scans(results, list_of_ranges):
     """Return labels of scans that include any of ``list_of_ranges``.
 

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -28,6 +28,7 @@ def successful(creds, search, args):
         logger.debug('List Credentials: %s', json.dumps(vaultcreds))
 
     outpost_map = {}
+    outpost_creds = []
     if getattr(args, "target", None) and hasattr(tideway, "appliance"):
         try:
             token = getattr(args, "token", None)
@@ -36,10 +37,19 @@ def successful(creds, search, args):
                     with open(args.f_token, "r") as f:
                         token = f.read().strip()
             app = tideway.appliance(args.target, token)
-            outpost_map = api.map_outpost_credentials(app)
+            outpost_map, outpost_creds = api.map_outpost_credentials(app, include_details=True)
             logger.debug("Outpost credential map: %s", outpost_map)
         except Exception as e:  # pragma: no cover - network errors
             logger.error("Failed to retrieve outpost credentials: %s", e)
+
+    # Merge outpost credentials into the main vault list without duplicates
+    if isinstance(vaultcreds, list) and outpost_creds:
+        seen = {c.get("uuid") for c in vaultcreds if isinstance(c, dict)}
+        for cred in outpost_creds:
+            uuid = cred.get("uuid")
+            if uuid and uuid not in seen:
+                vaultcreds.append(cred)
+                seen.add(uuid)
 
     credsux_results = {}
     devinfosux = {}


### PR DESCRIPTION
## Summary
- allow `map_outpost_credentials` to optionally return full credential details alongside the UUID to URL mapping
- merge outpost credentials into the success report and propagate outpost URLs to rows
- add compatibility helpers and regression tests

## Testing
- `python -m pytest tests/test_builder.py::test_ip_analysis_empty_excludes tests/test_builder.py::test_ip_analysis_empty_scan_ranges tests/test_builder.py::test_overlapping_unscanned_connections -q`
- `python -m pytest tests/test_api.py::test_show_runs_excavate_routes_to_define_csv tests/test_api.py::test_discovery_runs_emits_ints_and_camel_headers tests/test_api.py::test_device_capture_candidates_defaults_sysobjectid -q`
- `python -m pytest tests/test_reporting.py::test_successful_includes_outpost_credentials -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5ab27ff7c8326adef9758aaf10fbc