### PR TITLE
Fix get_outpost_credential_map invocation

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1217,7 +1217,7 @@ def _gather_discovery_data(twsearch, twcreds, args):
 def outpost_creds(creds_ep, search_ep, appliance, args):
     """Report mapping of outpost credentials to their outposts."""
 
-    outpost_map = api.get_outpost_credential_map(appliance) or {}
+    outpost_map = api.get_outpost_credential_map(search_ep, appliance) or {}
 
     vault = api.get_json(creds_ep.get_vault_credentials)
     label_map = {

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -420,7 +420,7 @@ def test_outpost_creds_builds_rows(monkeypatch):
     op_map = {"op1": {"url": "http://op1", "credentials": ["c1", "c2"]}}
 
     monkeypatch.setattr(
-        reporting.api, "get_outpost_credential_map", lambda app: op_map
+        reporting.api, "get_outpost_credential_map", lambda search, app: op_map
     )
     monkeypatch.setattr(
         reporting.api,


### PR DESCRIPTION
## Summary
- pass search endpoint when building outpost credential map
- adjust test to reflect new API usage

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5cccba98c8326aceb915c96dff770