### PR TITLE
Handle missing appliance attribute in outpost credential report

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -530,7 +530,9 @@ def sensitive(search, args, dir):
 
 def outpost_creds(creds, search, args, dir):
     """Wrapper for the outpost credential report."""
-    appliance = getattr(creds, "appliance", None)
+    # Some endpoints do not expose an `appliance` attribute; use the endpoint
+    # itself when it provides the `get` method.
+    appliance = getattr(creds, "appliance", None) or (creds if hasattr(creds, "get") else None)
     reporting.outpost_creds(creds, search, appliance, args)
 
 def tpl_export(search, args, dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -543,3 +543,15 @@ def test_host_util_converts_numeric_columns(monkeypatch):
         assert isinstance(row[index_map[col]], int)
     assert "OS_Type" in header
 
+
+def test_outpost_creds_passes_endpoint_as_appliance(monkeypatch):
+    """Ensure outpost_creds uses the creds endpoint when no appliance attribute."""
+    dummy_creds = types.SimpleNamespace(get=lambda *a, **k: None)
+    dummy_search = object()
+    args = types.SimpleNamespace()
+    recorded = {}
+    def fake_outpost(creds_ep, search_ep, appliance, args_ep):
+        recorded['appliance'] = appliance
+    monkeypatch.setattr(api_mod.reporting, 'outpost_creds', fake_outpost)
+    api_mod.outpost_creds(dummy_creds, dummy_search, args, '/tmp')
+    assert recorded['appliance'] is dummy_creds


### PR DESCRIPTION
## Summary
- use credentials endpoint as fallback appliance when generating outpost credential report
- add regression test ensuring outpost credentials use endpoint when `appliance` attribute is absent

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ce326eec832682738c919daa78fe