### PR TITLE
fix: avoid duplicate cred opt data

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -351,15 +351,13 @@ def ordering(creds, search, args, apply):
     print(msg)
     logger.info(msg)
     for cred in credlist:
-        label = cred.get('label')
-        index = cred.get('index')
-        msg = '%s) %s' % (index, label)
+        label = cred.get("label")
+        index = cred.get("index")
+        msg = "%s) %s" % (index, label)
         logger.info(msg)
-        scope = cred.get("scopes") or []
-        if isinstance(scope, list):
-            scope = ", ".join(scope)
-        url = outpost_map.get(cred.get("uuid"))
-        data.append([index, label, scope, url])
+        # Previously, refresh data was appended to ``data`` here which resulted
+        # in the report containing rows without weighting or new index values.
+        # Only log the new order to avoid mixing datasets.
 
     if data:
         # ``normalize_headers`` returns ``(headers, lookup)`` with headers in

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -68,13 +68,19 @@ def test_ordering_inserts_instance_and_outpost(monkeypatch):
 
     builder.ordering(creds, DummySearch(), args, False)
 
-    # Verify the new key is propagated through the report
+    # Verify the new key is propagated through the report and that only
+    # weighted credentials are included with populated Scope and OutpostUrl.
     assert captured["name"] == "suggested_cred_opt"
-    assert captured["headers"][0] == "Discovery Instance"
-    assert "Scope" in captured["headers"]
-    assert "OutpostUrl" in captured["headers"]
-    assert captured["data"]
-    assert captured["data"][0][0] == "appl"
+    assert captured["headers"] == [
+        "Discovery Instance",
+        "Credential",
+        "CurrentIndex",
+        "Weighting",
+        "NewIndex",
+        "Scope",
+        "OutpostUrl",
+    ]
+    assert captured["data"] == [["appl", "c", 1, 99, 0, "s", "http://op"]]
 
 
 def _setup_schedule_patches(monkeypatch, cred_list, excludes, scan_ranges):


### PR DESCRIPTION
## Summary
- avoid mixing "New Credential Order" data into credential optimisation report
- ensure scope and outpost URL columns are preserved

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d0910090832685586d22e83378f5