### PR TITLE
Merge latest discovery fields into chosen records

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1208,6 +1208,32 @@ def _gather_discovery_data(twsearch, twcreds, args):
         chosen["when_was_that"] = latest.get("when_was_that")
         if latest.get("scan_end_raw"):
             chosen["scan_end_raw"] = latest.get("scan_end_raw")
+
+        # Merge selected fields from the latest record when missing in the chosen
+        # record. This ensures the most recent information (such as node update
+        # times or credential details) is available even if the "best" record is
+        # older because it contains identifying information like hostname.
+        merge_fields = [
+            "hostname",
+            "node_updated",
+            "credential_name",
+            "credential_login",
+            "last_credential",
+            "current_access",
+            "end_state",
+            "previous_end_state",
+            "reason_not_updated",
+            "session_results_logged",
+            "da_id",
+            "prev_da_id",
+            "next_node_id",
+            "last_marker",
+        ]
+
+        for field in merge_fields:
+            if chosen.get(field) in (None, "") and latest.get(field) not in (None, ""):
+                chosen[field] = latest.get(field)
+
         disco_data.append(chosen)
 
     return disco_data


### PR DESCRIPTION
## Summary
- ensure `_gather_discovery_data` backfills missing fields like `hostname`, `node_updated`, and credential details from the most recent discovery record
- cover field backfilling with new discovery analysis test

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d135d46083269576eebda9e9b48d