### PR TITLE
Pass discovery data to discovery_access report

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1245,7 +1245,16 @@ def discovery_access(twsearch, twcreds, args):
     """Generate basic discovery access report."""
     logger.info("Running Discovery Access Report")
     disco_data = _gather_discovery_data(twsearch, twcreds, args)
-    output.report([], [], args, name="discovery_access")
+
+    if disco_data:
+        headers, lookup = tools.normalize_headers(
+            disco_data[0].keys(), return_lookup=True
+        )
+        rows = [[record.get(lookup[h]) for h in headers] for record in disco_data]
+    else:
+        headers, rows = [], []
+
+    output.report(rows, headers, args, name="discovery_access")
     return disco_data
 
 


### PR DESCRIPTION
## Summary
- Send discovery access data and headers to `output.report` so records reach generated reports.
- Add regression test ensuring `discovery_access` outputs gathered rows.

## Testing
- `python -m pytest tests/test_reporting.py::test_discovery_access_handles_bad_api tests/test_reporting.py::test_discovery_access_outputs_records -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d13a0f008326a152a819218a2526