### PR TITLE
Add expected agent analysis and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,16 @@ The toolkit now offers a broad range of reports. Selected examples include:
 - **device_ids** – list unique device identities with a Guide % for each originating endpoint.
 - **devices** – summarize unique device profiles with last access and credential details.
 - **discovery_analysis** – export latest access details for each endpoint and compare consecutive runs to highlight state changes.
+- **expected_agents** – analyse installed software and list hosts missing common agents.
 - **ip_analysis** – run IP analysis report.
 - **schedules** – export discovery schedules along with the credentials that will be used.
 - **suggested_cred_opt** – display suggested order of credentials based on restricted IPs, exclusions, success/failure, privilege and type.
 
 Run `python3 dismal.py --help` to see the complete list as new reports continue to be added.
+
+To flag hosts missing common agents:
+
+```bash
+python3 dismal.py --access_method api -i <appliance> -u <user> -p <password> \
+    --excavate expected_agents
+```

--- a/core/api.py
+++ b/core/api.py
@@ -13,7 +13,7 @@ import pandas
 import tideway
 
 # Local
-from . import tools, output, builder, queries, defaults, reporting, access
+from . import tools, output, builder, queries, defaults, reporting, access, common_agents
 import socket
 
 logger = logging.getLogger("_api_")
@@ -788,6 +788,24 @@ def capture_candidates(search, args, dir):
 @output._timer("Agents")
 def agents(search, args, dir):
     output.define_csv(args,search,queries.agents,dir+defaults.installed_agents_filename,args.output_file,args.target,"query")
+
+@output._timer("Expected Agents")
+def expected_agents(search, args, dir):
+    """Report hosts missing common agents via the API."""
+
+    results = search_results(search, queries.agents)
+    records = []
+    for row in results:
+        running = tools.getr(row, "Running_Software", "") or ""
+        softwares = [s.strip() for s in running.split(";") if s.strip()]
+        records.append({"Host_Name": tools.getr(row, "Host_Name", ""), "Running_Software": softwares})
+    expected = common_agents.get_expected_agents(records)
+    if expected:
+        print("Expected agents: %s" % ", ".join(sorted(expected)))
+    missing = common_agents.find_missing_agents(records, expected)
+    data = [[rec["Host_Name"], ";".join(rec["Missing_Agents"])] for rec in missing]
+    headers = ["Host Name", "Missing Agents"]
+    output.report(data, headers, args, name="expected_agents")
 
 @output._timer("Software Users")
 def software_users(search, args, dir):

--- a/core/common_agents.py
+++ b/core/common_agents.py
@@ -1,0 +1,78 @@
+
+"""Common agent analysis utilities.
+
+This module parses agent inventory data and determines which software
+packages appear on a significant proportion of hosts. These are treated
+as the "expected" agents for the environment. Hosts missing any of the
+expected agents can then be identified.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from typing import Iterable, List, Dict, Set
+
+
+def parse_agent_csv(csv_text: str) -> List[Dict[str, object]]:
+    """Return records from the ``installed_agents`` CSV output.
+
+    Parameters
+    ----------
+    csv_text:
+        Raw CSV string with at least ``Host_Name`` and ``Running_Software``
+        fields.
+    """
+
+    reader = csv.DictReader(csv_text.splitlines())
+    records: List[Dict[str, object]] = []
+    for row in reader:
+        software_field = row.get("Running_Software", "") or ""
+        softwares = [s.strip() for s in software_field.split(";") if s.strip()]
+        row["Running_Software"] = softwares
+        records.append(row)
+    return records
+
+
+def get_expected_agents(records: Iterable[Dict[str, object]], threshold: float = 0.5) -> Set[str]:
+    """Return agents present on at least ``threshold`` proportion of hosts.
+
+    Parameters
+    ----------
+    records:
+        Iterable of host records with a ``Running_Software`` list field.
+    threshold:
+        Fraction of hosts that must contain a piece of software for it to be
+        considered "expected".
+    """
+
+    counts: Counter[str] = Counter()
+    total = 0
+    for rec in records:
+        total += 1
+        counts.update(set(rec.get("Running_Software", [])))
+    if total == 0:
+        return set()
+    return {name for name, count in counts.items() if count / total >= threshold}
+
+
+def find_missing_agents(records: Iterable[Dict[str, object]], expected: Set[str]) -> List[Dict[str, object]]:
+    """Return hosts missing any of the ``expected`` agents.
+
+    The ``Running_Software`` field of each record should be a list of software
+    names.  The result is a list of dictionaries containing ``Host_Name`` and a
+    list of ``Missing_Agents`` for that host.
+    """
+
+    missing: List[Dict[str, object]] = []
+    for rec in records:
+        running = set(rec.get("Running_Software", []))
+        absent = sorted(expected - running)
+        if absent:
+            missing.append(
+                {
+                    "Host_Name": rec.get("Host_Name", ""),
+                    "Missing_Agents": absent,
+                }
+            )
+    return missing

--- a/core/queries.py
+++ b/core/queries.py
@@ -601,7 +601,7 @@ agents = """
                 name as "Host_Name",
                 hash(name) as 'hashed_name',
                 os_version as "OS_Version",
-                #:::SoftwareInstance.name as "Running_Software",
+                #HostedSoftware:RunningSoftware:SoftwareInstance.name as "Running_Software",
                 serial as "Serial",
                 uuid as "UUID",
                 ((age_count < 0) and 'Aging' or 'Alive') as 'Age_Status',

--- a/dismal.py
+++ b/dismal.py
@@ -152,6 +152,7 @@ Providing no <report> or using "default" will run all options that do not requir
 "host_utilisation"          - Export of Hosts which appear to be underutilised (less than 3 running SIs)
 "hostname"                  - Print hostname
 "installed_agents"          - Analysis of installed agents
+"expected_agents"          - Report hosts missing expected agents
 "ipaddr" <ip_address>       - Search specific IP address for DiscoveryAccess results
 "missing_vms"               - Report of Hypervisor Hosts that have VMs which have not been discovered
 "near_removal"              - Export list of devices near removal
@@ -345,6 +346,7 @@ def run_for_args(args):
             cli.unrecognised_snmp(cli_target, args, system_user, system_passwd, reporting_dir)
             cli.capture_candidates(cli_target, args, system_user, system_passwd, reporting_dir)
             cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
+            cli.expected_agents(cli_target, args, system_user, system_passwd, reporting_dir)
             cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
             cli.module_summary(cli_target, args, system_user, system_passwd, reporting_dir)
 
@@ -381,6 +383,7 @@ def run_for_args(args):
             api.slc(search, args, reporting_dir)
             api.dblc(search, args, reporting_dir)
             api.agents(search, args, reporting_dir)
+            api.expected_agents(search, args, reporting_dir)
             api.software_users(search, args, reporting_dir)
             api.tku(knowledge, args, reporting_dir)
             api.outpost_creds(creds, search, args, reporting_dir)
@@ -537,6 +540,9 @@ def run_for_args(args):
 
         if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
             cli.installed_agents(cli_target, args, system_user, system_passwd, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "expected_agents"):
+            cli.expected_agents(cli_target, args, system_user, system_passwd, reporting_dir)
 
         if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
             cli.software_usernames(cli_target, args, system_user, system_passwd, reporting_dir)
@@ -730,6 +736,9 @@ def run_for_args(args):
 
         if excavate_default or (args.excavate and args.excavate[0] == "installed_agents"):
             api.agents(search, args, reporting_dir)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "expected_agents"):
+            api.expected_agents(search, args, reporting_dir)
 
         if excavate_default or (args.excavate and args.excavate[0] == "si_user_accounts"):
             api.software_users(search, args, reporting_dir)

--- a/tests/test_common_agents.py
+++ b/tests/test_common_agents.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core import common_agents
+
+
+def test_expected_and_missing_agents_detection():
+    csv_data = (
+        "Host_Name,Running_Software\n"
+        "host1,AgentA;AgentB\n"
+        "host2,AgentA;AgentC\n"
+        "host3,AgentA;AgentB\n"
+    )
+    records = common_agents.parse_agent_csv(csv_data)
+    expected = common_agents.get_expected_agents(records, threshold=0.6)
+    assert expected == {"AgentA", "AgentB"}
+    missing = common_agents.find_missing_agents(records, expected)
+    assert missing == [{"Host_Name": "host2", "Missing_Agents": ["AgentB"]}]
+


### PR DESCRIPTION
## Summary
- extend agents query to include full running software names
- add common agent analysis utilities and CLI/API reports
- document new `expected_agents` report and cover with tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d16b45308326b709f1cef3c87979