### PR TITLE
Handle API result structure variations in IP analysis

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -351,6 +351,38 @@ def test_ip_analysis_empty_scan_ranges(monkeypatch, capsys):
     assert "No scan ranges found" in out
 
 
+def test_ip_analysis_dict_responses(monkeypatch):
+    scan_ranges = {
+        "results": [
+            {"Scan_Range": ["10.0.0.0/24"], "Label": "r1"},
+            {"Scan_Range": ["10.0.0.0/24"], "Label": "r2"},
+        ]
+    }
+    excludes = {
+        "results": [{"Scan_Range": ["10.0.1.0/24"], "Label": "ex"}] 
+    }
+    search, args, captured = _setup_ip_analysis_patches(monkeypatch, scan_ranges, excludes)
+
+    builder.ip_analysis(search, args)
+
+    assert captured["data"] == [["10.0.0.0/24", ["r1", "r2"]]]
+
+
+def test_ip_analysis_list_responses(monkeypatch):
+    scan_ranges = [
+        {"Scan_Range": ["10.0.0.0/24"], "Label": "r1"},
+        {"Scan_Range": ["10.0.0.0/24"], "Label": "r2"},
+    ]
+    excludes = [
+        {"Scan_Range": ["10.0.1.0/24"], "Label": "ex"}
+    ]
+    search, args, captured = _setup_ip_analysis_patches(monkeypatch, scan_ranges, excludes)
+
+    builder.ip_analysis(search, args)
+
+    assert captured["data"] == [["10.0.0.0/24", ["r1", "r2"]]]
+
+
 def test_overlapping_unscanned_connections(monkeypatch):
     search_results_returns = [
         [],


### PR DESCRIPTION
## Summary
- Allow `ip_analysis` to parse scan range and exclude responses in either list or dict form
- Add regression tests covering both response formats

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62dd4b4ac832688b4c6cbc3ff285d