### PR TITLE
Handle empty report data

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -203,16 +203,20 @@ def report(data, heads, args, name=None):
                 csv_file(data, heads, os.path.join(out_dir, f"{name}.csv"))
                 logger.info("Output to CSV file")
     else:
-        msg = "No results found!\n"
-        if cli_out:
-            print(msg)
+        msg = "No results found!"
+        # Always provide visible feedback when no data is returned
+        print(msg)
         logger.warning(msg)
 
+        # When writing to a file, still generate a CSV with a note so
+        # consumers know the report executed but returned nothing.
+        note_row = ["No data returned"] + [""] * (len(heads) - 1 if heads else 0)
+
         if args.output_file:
-            csv_file(data, heads, args.output_file)
+            csv_file([note_row], heads, args.output_file)
             logger.info("Output to CSV file")
         elif excavate is not None and name and out_dir:
-            csv_file(data, heads, os.path.join(out_dir, f"{name}.csv"))
+            csv_file([note_row], heads, os.path.join(out_dir, f"{name}.csv"))
             logger.info("Output to CSV file")
 
 def cmd2csv(header,result,seperator,filename,appliance):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -56,3 +56,56 @@ def test_save2csv_numeric(tmp_path):
     with open(filename, newline="") as fh:
         row = next(csv.DictReader(fh))
     assert int(row["Consecutive Scan Failures"]) == -5
+
+
+def test_report_empty_prints_message(capsys):
+    args = types.SimpleNamespace(
+        output_cli=True,
+        output_null=False,
+        output_csv=False,
+        output_file=None,
+        excavate=None,
+        reporting_dir=None,
+    )
+    output.report([], ["Col"], args)
+    out = capsys.readouterr().out
+    assert "No results found!" in out
+
+
+def test_report_empty_file_output(tmp_path, capsys):
+    outfile = tmp_path / "empty.csv"
+    args = types.SimpleNamespace(
+        output_cli=False,
+        output_null=False,
+        output_csv=False,
+        output_file=str(outfile),
+        excavate=None,
+        reporting_dir=None,
+    )
+    output.report([], ["Col1", "Col2"], args)
+    out = capsys.readouterr().out
+    # message should still be printed even without output_cli
+    assert "No results found!" in out
+    with open(outfile, newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0] == ["Col1", "Col2"]
+    assert rows[1][0] == "No data returned"
+
+
+def test_report_empty_excavate_output(tmp_path, capsys):
+    args = types.SimpleNamespace(
+        output_cli=False,
+        output_null=False,
+        output_csv=False,
+        output_file=None,
+        excavate=True,
+        reporting_dir=str(tmp_path),
+    )
+    output.report([], ["A"], args, name="sample")
+    out = capsys.readouterr().out
+    assert "No results found!" in out
+    csv_path = tmp_path / "sample.csv"
+    with open(csv_path, newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0] == ["A"]
+    assert rows[1][0] == "No data returned"


### PR DESCRIPTION
## Summary
- ensure report() always prints a 'No results found!' message
- write CSV files with headers and a note when no data is returned
- add tests for empty results in CLI, file output, and excavate modes

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a62dd55a4c8326bc3e16289164ec1f