### PR TITLE
Add discovery run analysis report

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The toolkit now offers a broad range of reports. Selected examples include:
 - **device_ids** – list unique device identities with a Guide % for each originating endpoint.
 - **devices** – summarize unique device profiles with last access and credential details.
 - **discovery_analysis** – export latest access details for each endpoint and compare consecutive runs to highlight state changes.
+- **discovery_run_analysis** – summarises DiscoveryRun details including ranges, endpoint totals, and scan kinds.
 - **expected_agents** – analyse installed software and list hosts missing common agents.
 - **ip_analysis** – run IP analysis report.
 - **schedules** – export discovery schedules along with the credentials that will be used.

--- a/core/queries.py
+++ b/core/queries.py
@@ -642,3 +642,23 @@ patterns =    """
                     extra_node_kinds as 'Extra_Node_Kinds',
                     extra_rel_kinds as 'Extra_Rel_Kinds'
                 """
+
+discovery_run_analysis = """
+                    search DiscoveryRun as DiscoveryRun
+                      with (traverse :::ScanRange as ScanRange),
+                           (traverse :::DroppedEndpoints as DroppedEndpoints),
+                           (traverse :::DiscoveryAccess as DiscoveryAccess)
+                      show valid_ranges as 'Explicit Ranges', label as 'Scan Label',
+                           range_summary as 'Range Summary', outpost_name as 'Outpost Name',
+                           #ScanRange.label as 'Label', #ScanRange.scan_kind as 'Scan Kind',
+                           (#ScanRange.range_strings or #ScanRange.provider) as 'Range',
+                           recurrenceDescription(#ScanRange.schedule) as 'Schedule',
+                           total as 'Total Endpoints',
+                           (result_success or 0) + (result_skipped or 0) + (result_error or 0) +
+                           (result_no_access or 0) + (result_no_response or 0) as 'Active Endpoints',
+                           (result_dropped or 0) as 'Dropped',
+                           unique(#DiscoveryAccess.scan_kind) as 'Scan Kinds'
+                      processwith show valid_ranges, label, endtime as 'End Time',
+                           range_summary, outpost_name, @4, @5, @6, @7, total, @9, @10,
+                           @11 as 'Scan Kinds'
+                """

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1443,6 +1443,23 @@ def discovery_analysis(twsearch, twcreds, args, disco_data=None):
     output.report(data, headers, args, name="discovery_analysis")
 
 
+@output._timer("Discovery Run Analysis")
+def discovery_run_analysis(twsearch, twcreds, args):
+    """Report on discovery run ranges and endpoint statistics."""
+    logger.info("Running Discovery Run Analysis report")
+    results = api.search_results(twsearch, queries.discovery_run_analysis)
+
+    if isinstance(results, list) and results:
+        headers, lookup = tools.normalize_headers(
+            results[0].keys(), return_lookup=True
+        )
+        rows = [[record.get(lookup[h]) for h in headers] for record in results]
+    else:
+        headers, rows = [], []
+
+    output.report(rows, headers, args, name="discovery_run_analysis")
+
+
 @output._timer("TPL Export")
 def tpl_export(search, query, dir, method, client, sysuser, syspass):
     tpldir = dir + "/tpl"

--- a/dismal.py
+++ b/dismal.py
@@ -172,6 +172,7 @@ Providing no <report> or using "default" will run all options that do not requir
 "capture_candidates" - Report of capture candidates
 "outpost_creds"            - Mapping of credentials to Outposts
 "vault"                     - Vault details
+"discovery_run_analysis"   - Report on DiscoveryRun ranges and endpoint stats
 "default"                   - Run all options that do not require a value
 \n
 ''',metavar='<report> [value]',nargs='*')
@@ -688,6 +689,9 @@ def run_for_args(args):
         if args.excavate and args.excavate[0] == "discovery_analysis":
             disco_data = reporting._gather_discovery_data(search, creds, args)
             reporting.discovery_analysis(search, creds, args, disco_data)
+
+        if excavate_default or (args.excavate and args.excavate[0] == "discovery_run_analysis"):
+            reporting.discovery_run_analysis(search, creds, args)
 
         if excavate_default or (args.excavate and args.excavate[0] == "active_runs"):
             api.show_runs(disco, args)

--- a/merge_outputs.py
+++ b/merge_outputs.py
@@ -10,6 +10,7 @@ EXPECTED_REPORTS = OrderedDict([
     ("device_ids", "List of unique device identifiers"),
     ("devices", "Detailed device information"),
     ("discovery_analysis", "Summary of discovery analysis results"),
+    ("discovery_run_analysis", "Summary of discovery run activity"),
     ("devices_with_cred", "Devices with associated credentials"),
     ("device", "Information for individual devices"),
     ("suggested_cred_opt", "Suggested credential optimization"),


### PR DESCRIPTION
## Summary
- add `discovery_run_analysis` query for summarising DiscoveryRun ranges and endpoint stats
- expose Discovery Run Analysis report via CLI and merge script
- document new report and test reporting helper

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a70dd6f934832694bdddc5b0664e9b