### PR TITLE
Refactor header handling and query aliases

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -360,11 +360,7 @@ def ordering(creds, search, args, apply):
         # Only log the new order to avoid mixing datasets.
 
     if data:
-        # ``normalize_headers`` returns ``(headers, lookup)`` with headers in
-        # Title Case. Convert the header names to a mutable list and then to
-        # CamelCase so we can safely insert additional labels.
-        headers = list(tools.normalize_headers(headers, return_lookup=True)[0])
-        headers = [tools.normalize_header(h) for h in headers]
+        headers = list(dict.fromkeys(headers))
         headers.insert(0, "Discovery Instance")
         for row in data:
             row.insert(0, getattr(args, "target", None))

--- a/core/cli.py
+++ b/core/cli.py
@@ -277,7 +277,7 @@ def baseline(client,args,dir):
         for checks in checklist.split("\n"):
             check = checks.split(":")
             checked.append([s.strip() for s in check])
-    header = tools.normalize_headers(header)
+    header = list(dict.fromkeys(header))
     header.insert(0,"Discovery Instance")
     for row in checked:
         row.insert(0, args.target)

--- a/core/output.py
+++ b/core/output.py
@@ -221,7 +221,6 @@ def report(data, heads, args, name=None):
 
 def cmd2csv(header,result,seperator,filename,appliance):
     data = []
-    header = tools.normalize_headers(header)
     header.insert(0,"Discovery Instance")
     for line in result.split("\r\n"):
         lines = line.split("\n")
@@ -282,7 +281,7 @@ def define_csv(args, head_ep, data, path, file, target, type, tku=None):
 
     cli_out = getattr(args, "output_cli", False)
     if isinstance(head_ep, list):
-        head_ep = tools.normalize_keys(head_ep)
+        head_ep = list(head_ep)
     if type == "cmd":
         if args.output_file:
             cmd2csv(head_ep, data, ":", file, target)

--- a/core/queries.py
+++ b/core/queries.py
@@ -2,34 +2,34 @@
 
 credential_success = """
                             search SessionResult where success
-                            show (slave or credential) as 'UUID',
-                            session_type as 'Session_Type'
+                            show (slave or credential) as 'SessionResult.credential',
+                            session_type as 'SessionResult.session_type'
                             processwith countUnique(1,0)
                         """
 credential_failure = """
                             search SessionResult where not success
-                            show (slave or credential) as 'UUID',
-                            session_type as 'Session_Type'
+                            show (slave or credential) as 'SessionResult.credential',
+                            session_type as 'SessionResult.session_type'
                             processwith countUnique(1,0)
                         """
 deviceinfo_success = """
                           search DeviceInfo where method_success and __had_inference
                           and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess
                                             traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
-                          show (last_credential or last_slave) as 'UUID',
-                          access_method as 'Session_Type'
+                          show (last_credential or last_slave) as 'DeviceInfo.last_credential',
+                          access_method as 'DeviceInfo.access_method'
                           process with countUnique(1,0)
                        """
 credential_success_7d = """
                             search SessionResult where success and time_index > (currentTime() - 7*24*3600*10000000)
-                            show (slave or credential) as 'UUID',
-                            session_type as 'Session_Type'
+                            show (slave or credential) as 'SessionResult.credential',
+                            session_type as 'SessionResult.session_type'
                             processwith countUnique(1,0)
                         """
 credential_failure_7d = """
                             search SessionResult where not success and time_index > (currentTime() - 7*24*3600*10000000)
-                            show (slave or credential) as 'UUID',
-                            session_type as 'Session_Type'
+                            show (slave or credential) as 'SessionResult.credential',
+                            session_type as 'SessionResult.session_type'
                             processwith countUnique(1,0)
                         """
 deviceinfo_success_7d = """
@@ -37,8 +37,8 @@ deviceinfo_success_7d = """
                           and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess
                                             traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
                           and time_index > (currentTime() - 7*24*3600*10000000)
-                          show (last_credential or last_slave) as 'UUID',
-                          access_method as 'Session_Type'
+                          show (last_credential or last_slave) as 'DeviceInfo.last_credential',
+                          access_method as 'DeviceInfo.access_method'
                           process with countUnique(1,0)
                        """
 outpost_credentials = """
@@ -51,26 +51,26 @@ deviceInfo = {"query":
                             search DeviceInfo
                             ORDER BY hostname
                             show
-                            hostname as 'Device_Hostname',
-                            hash(hostname) as 'Hashed_Device_Hostname',
-                            os_type as 'OS_Type',
-                            sysname as 'Device_Sysname',
-                            device_type as 'Device_Type',
-                            fqdn as 'Device_FQDN',
-                            method_success as 'M_Success',
-                            method_failure as 'M_Failure',
+                            hostname as 'DeviceInfo.hostname',
+                            hash(hostname) as 'DeviceInfo.hostname_hash',
+                            os_type as 'DeviceInfo.os_type',
+                            sysname as 'DeviceInfo.sysname',
+                            device_type as 'DeviceInfo.device_type',
+                            fqdn as 'DeviceInfo.fqdn',
+                            method_success as 'DeviceInfo.method_success',
+                            method_failure as 'DeviceInfo.method_failure',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.name as 'Inferred_Name',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.hostname as 'Inferred_Hostname',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.local_fqdn as 'Inferred_FQDN',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.sysname as 'Inferred_Sysname',
                             kind as 'Kind',
-                            (last_credential or last_slave or __preserved_last_credential) as 'Last_Credential',
-                            (last_access_method or __preserved_last_access_method) as 'Last_Access_Method',
-                            friendlyTime(#DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.starttime) as 'DA_Start',
-                            friendlyTime(#DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endtime) as 'DA_End',
-                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.result as 'DA_Result',
-                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endpoint as 'DA_Endpoint',
-                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.end_state as 'DA_End_State',
+                            (last_credential or last_slave or __preserved_last_credential) as 'DeviceInfo.last_credential',
+                            (last_access_method or __preserved_last_access_method) as 'DeviceInfo.last_access_method',
+                            friendlyTime(#DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.starttime) as 'DiscoveryAccess.starttime',
+                            friendlyTime(#DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endtime) as 'DiscoveryAccess.endtime',
+                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.result as 'DiscoveryAccess.result',
+                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endpoint as 'DiscoveryAccess.endpoint',
+                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.end_state as 'DiscoveryAccess.end_state',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#DiscoveryAccess:Endpoint:Endpoint:Endpoint.endpoint as 'Chosen_Endpoint',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DiscoveredIPAddressList.#List:List:Member:DiscoveredIPAddress.ip_addr as 'Discovered_IP_Addrs',
                             #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.__all_ip_addrs as 'Inferred_All_IP_Addrs',
@@ -318,17 +318,17 @@ open_ports = """
 host_utilisation = """
                         search Host where type <> 'Hypervisor'
                         show
-                        hostname,
-                        hash(hostname) as 'hashed_hostname',
-                        os,
-                        os_type as 'OS_Type',
-                        virtual,
-                        cloud,
-                        #InferredElement:Inference:Associate:DiscoveryAccess.endpoint as 'Endpoint',
-                        nodecount(traverse :::SoftwareInstance) as 'Running Software Instances',
-                        nodecount(traverse :::CandidateSoftwareInstance) as 'Candidate Software Instances',
-                        nodecount(traverse :::DiscoveryAccess where _last_marker traverse :::ProcessList traverse :::DiscoveredProcess) as 'Running Processes',
-                        nodecount(traverse :::DiscoveryAccess where _last_marker traverse :::ServiceList traverse :::DiscoveredService where state = 'RUNNING') as 'Running Services (Windows)'
+                        hostname as 'Host.hostname',
+                        hash(hostname) as 'Host.hostname_hash',
+                        os as 'Host.os',
+                        os_type as 'Host.os_type',
+                        virtual as 'Host.virtual',
+                        cloud as 'Host.cloud',
+                        #InferredElement:Inference:Associate:DiscoveryAccess.endpoint as 'DiscoveryAccess.endpoint',
+                        nodecount(traverse :::SoftwareInstance) as 'Host.running_software_instances',
+                        nodecount(traverse :::CandidateSoftwareInstance) as 'Host.candidate_software_instances',
+                        nodecount(traverse :::DiscoveryAccess where _last_marker traverse :::ProcessList traverse :::DiscoveredProcess) as 'Host.running_processes',
+                        nodecount(traverse :::DiscoveryAccess where _last_marker traverse :::ServiceList traverse :::DiscoveredService where state = 'RUNNING') as 'Host.running_services'
                       """
 
 orphan_vms = """
@@ -576,14 +576,14 @@ missing_vms = """
                     search VirtualMachine
                     where nodecount(traverse HostContainer:HostContainment:ContainedHost:) = 0
                     show
-                    vm_type as 'VM_Type',
-                    (product_version or cloud_class) as 'VM_Version',
-                    #RunningSoftware:HostedSoftware:Host:.name as 'VM_Host',
-                    #RunningSoftware:HostedSoftware:Host:.type as 'VM_Host_Type',
-                    vm_name as 'Guest_VM_Name',
-                    vm_guest_os as 'Guest_VM_OS',
-                    guest_full_name as 'Guest_Full_Name',
-                    (vm_status or cloud and "Cloud Hosted") as 'Status'
+                    vm_type as 'VirtualMachine.vm_type',
+                    (product_version or cloud_class) as 'VirtualMachine.product_version',
+                    #RunningSoftware:HostedSoftware:Host:.name as 'Host.name',
+                    #RunningSoftware:HostedSoftware:Host:.type as 'Host.type',
+                    vm_name as 'VirtualMachine.vm_name',
+                    vm_guest_os as 'VirtualMachine.vm_guest_os',
+                    guest_full_name as 'VirtualMachine.guest_full_name',
+                    (vm_status or cloud and "Cloud Hosted") as 'VirtualMachine.vm_status'
                 """
 
 agents = """

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -376,7 +376,7 @@ def successful(creds, search, args):
     print(os.linesep,end="\r")
 
     if data:
-        headers = tools.normalize_headers(headers)
+        headers = list(dict.fromkeys(headers))
         headers.insert(0, "Discovery Instance")
         for row in data:
             row.insert(0, getattr(args, "target", None))
@@ -462,7 +462,7 @@ def successful_cli(client, args, sysuser, passwd, reporting_dir):
             data.append([ detail.get('label'), uuid, detail.get('username'), types, None, None, 0.0, "Credential appears to not be in use (%s)" % status, detail.get('usage'), detail.get('internal_store'), list_of_ranges, ip_exclude ])
         headers = [ "Credential", "UUID", "Login ID", "Protocol", "Successes", "Failures", "Success %", "State", "Usage", "Store", "Scan Ranges", "Exclude Ranges" ]
 
-    headers = tools.normalize_headers(headers)
+    headers = list(dict.fromkeys(headers))
     headers.insert(0,"Discovery Instance")
     for row in data:
         row.insert(0, args.target)
@@ -1295,10 +1295,8 @@ def discovery_access(twsearch, twcreds, args):
     disco_data = _gather_discovery_data(twsearch, twcreds, args)
 
     if disco_data:
-        headers, lookup = tools.normalize_headers(
-            disco_data[0].keys(), return_lookup=True
-        )
-        rows = [[record.get(lookup[h]) for h in headers] for record in disco_data]
+        headers = list(dict.fromkeys(disco_data[0].keys()))
+        rows = [[record.get(h) for h in headers] for record in disco_data]
     else:
         headers, rows = [], []
 
@@ -1450,10 +1448,8 @@ def discovery_run_analysis(twsearch, twcreds, args):
     results = api.search_results(twsearch, queries.discovery_run_analysis)
 
     if isinstance(results, list) and results:
-        headers, lookup = tools.normalize_headers(
-            results[0].keys(), return_lookup=True
-        )
-        rows = [[record.get(lookup[h]) for h in headers] for record in results]
+        headers = list(dict.fromkeys(results[0].keys()))
+        rows = [[record.get(h) for h in headers] for record in results]
     else:
         headers, rows = [], []
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,6 @@ from core.api import (
     get_outpost_credential_map,
 )
 import core.api as api_mod
-from core.tools import normalize_keys
 from core import queries, tools
 import core.access as access
 
@@ -154,7 +153,7 @@ def test_show_runs_excavate_routes_to_define_csv(monkeypatch):
 
     show_runs(disco, args)
 
-    assert recorded["header"] == normalize_keys(["Run Id", "Status"])
+    assert recorded["header"] == ["run_id", "status"]
     assert recorded["data"] == [["1", "running"]]
 
 
@@ -179,10 +178,17 @@ def test_discovery_runs_emits_ints_and_camel_headers(monkeypatch):
 
     api_mod.discovery_runs(disco, args, "/tmp")
 
-    assert captured["header"] == ["Discovery Instance", "Done", "Pre Scanning", "Range Id", "Scanning", "Total"]
-    assert captured["rows"] == [["appl", 1, 2, "r1", 3, 4]]
+    assert captured["header"] == [
+        "Discovery Instance",
+        "range_id",
+        "done",
+        "pre_scanning",
+        "scanning",
+        "total",
+    ]
+    assert captured["rows"] == [["appl", "r1", 1, 2, 3, 4]]
     row = captured["rows"][0]
-    for index in [1, 2, 4, 5]:
+    for index in [2, 3, 4, 5]:
         assert isinstance(row[index], int)
 
 def test_get_outposts_uses_deleted_false():
@@ -469,8 +475,8 @@ def test_capture_candidates_writes_csv(monkeypatch):
 
     api_mod.capture_candidates(types.SimpleNamespace(), args, "/tmp")
 
-    keys = sorted(results[0])
-    expected_header = ["Discovery Instance"] + normalize_keys(keys)
+    keys = list(results[0].keys())
+    expected_header = ["Discovery Instance"] + keys
     expected_row = [
         "appl"
     ] + [
@@ -532,17 +538,17 @@ def test_update_schedule_timezone_reset():
 def test_host_util_converts_numeric_columns(monkeypatch):
     sample = [
         {
-            "hostname": "h1",
-            "hashed_hostname": "hash",
-            "os": "Linux",
-            "OS_Type": "Linux",
-            "virtual": False,
-            "cloud": False,
-            "Endpoint": "ep",
-            "Running Software Instances": "1",
-            "Candidate Software Instances": "2",
-            "Running Processes": "3",
-            "Running Services (Windows)": "4",
+            "Host.hostname": "h1",
+            "Host.hostname_hash": "hash",
+            "Host.os": "Linux",
+            "Host.os_type": "Linux",
+            "Host.virtual": False,
+            "Host.cloud": False,
+            "DiscoveryAccess.endpoint": "ep",
+            "Host.running_software_instances": "1",
+            "Host.candidate_software_instances": "2",
+            "Host.running_processes": "3",
+            "Host.running_services": "4",
         }
     ]
 
@@ -565,13 +571,13 @@ def test_host_util_converts_numeric_columns(monkeypatch):
     row = recorded["rows"][0]
     index_map = {h: i for i, h in enumerate(header)}
     for col in [
-        "Running Software Instances",
-        "Candidate Software Instances",
-        "Running Processes",
-        "Running Services (Windows)",
+        "Host.running_software_instances",
+        "Host.candidate_software_instances",
+        "Host.running_processes",
+        "Host.running_services",
     ]:
         assert isinstance(row[index_map[col]], int)
-    assert "OS_Type" in header
+    assert "Host.os_type" in header
 
 
 def test_outpost_creds_passes_endpoint_as_appliance(monkeypatch):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -74,11 +74,11 @@ def test_ordering_inserts_instance_and_outpost(monkeypatch):
     assert captured["headers"] == [
         "Discovery Instance",
         "Credential",
-        "CurrentIndex",
+        "Current Index",
         "Weighting",
-        "NewIndex",
+        "New Index",
         "Scope",
-        "OutpostUrl",
+        "Outpost URL",
     ]
     assert captured["data"] == [["appl", "c", 1, 99, 0, "s", "http://op"]]
 

--- a/tests/test_missing_vms.py
+++ b/tests/test_missing_vms.py
@@ -10,7 +10,6 @@ sys.modules.setdefault("paramiko", types.SimpleNamespace())
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import core.api as api_mod
-from core.tools import normalize_keys
 
 class DummySearch:
     def search(self, query, format="object", limit=500):
@@ -19,8 +18,8 @@ class DummySearch:
 
 def test_missing_vms_calls_completage(monkeypatch):
     results = [
-        {"Guest_Full_Name": "h1"},
-        {"Guest_Full_Name": "h2"},
+        {"VirtualMachine.guest_full_name": "h1"},
+        {"VirtualMachine.guest_full_name": "h2"},
     ]
 
     monkeypatch.setattr(api_mod, "search_results", lambda *a, **k: results)
@@ -44,13 +43,13 @@ def test_missing_vms_calls_completage(monkeypatch):
 
 
 def test_missing_vms_enriches_from_devices(monkeypatch):
-    missing = [{"Guest_Full_Name": "h1"}]
+    missing = [{"VirtualMachine.guest_full_name": "h1"}]
 
     device_info = [{
-        "DA_Endpoint": "1.2.3.4",
-        "Device_Hostname": "id1",
-        "DA_Start": "2024-01-01 10:00:00",
-        "DA_Result": "OK",
+        "DiscoveryAccess.endpoint": "1.2.3.4",
+        "DeviceInfo.hostname": "id1",
+        "DiscoveryAccess.starttime": "2024-01-01 10:00:00",
+        "DiscoveryAccess.result": "OK",
     }]
 
     def fake_search_results(search, query):
@@ -76,9 +75,9 @@ def test_missing_vms_enriches_from_devices(monkeypatch):
 
     api_mod.missing_vms(DummySearch(), args, "")
 
-    assert captured["header"][-3:] == normalize_keys([
+    assert captured["header"][-3:] == [
         "last_identity",
         "last_scanned",
         "last_result",
-    ])
+    ]
     assert captured["data"][0][-3:] == ["id1", "2024-01-01 10:00:00", "OK"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -132,7 +132,7 @@ def test_discovery_access_outputs_records(monkeypatch):
 
     assert result == sample
     assert captured["name"] == "discovery_access"
-    assert captured["headers"] == ["Endpoint", "Hostname"]
+    assert captured["headers"] == ["endpoint", "hostname"]
     assert captured["data"] == [["1.1.1.1", "h1"], ["2.2.2.2", "h2"]]
 
 
@@ -171,7 +171,7 @@ def test_discovery_run_analysis_outputs_records(monkeypatch):
     reporting.discovery_run_analysis(DummySearch(), DummyCreds(), args)
 
     assert captured["name"] == "discovery_run_analysis"
-    expected_headers = tools.normalize_headers(sample[0].keys())
+    expected_headers = list(sample[0].keys())
     assert captured["headers"] == expected_headers
     assert captured["data"] == [list(sample[0].values())]
 
@@ -261,7 +261,7 @@ def test_successful_combines_query_results(monkeypatch):
         reporting.queries.deviceinfo_success_7d,
         reporting.queries.credential_failure_7d,
     }
-    assert "Success % 7 days" in captured["headers"]
+    assert "Success % 7 Days" in captured["headers"]
     row = captured["data"][0]
     assert row[6] == 5
     assert row[7] == 4

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,9 +36,16 @@ def test_dequote_no_change():
     assert tools.dequote("'hello'") == "'hello'"
 
 
-def test_json2csv_returns_normalized_headers_and_map():
-    data = [{"first_name": "Jane", "last_name": "Doe"}]
+def test_json2csv_returns_raw_headers_and_map():
+    data = [
+        {"first_name": "Jane", "last_name": "Doe"},
+        {"first_name": "John", "age": 30},
+    ]
     header, rows, lookup = tools.json2csv(data, return_map=True)
-    assert header == ["First Name", "Last Name"]
-    assert rows == [["Jane", "Doe"]]
-    assert lookup == {"First Name": "first_name", "Last Name": "last_name"}
+    assert header == ["first_name", "last_name", "age"]
+    assert rows == [["Jane", "Doe", "N/A"], ["John", "N/A", 30]]
+    assert lookup == {
+        "first_name": "first_name",
+        "last_name": "last_name",
+        "age": "age",
+    }


### PR DESCRIPTION
## Summary
- remove header normalization utilities and return raw, de-duplicated headers from json2csv
- prefix query aliases with `<Node>.<field>` and consume raw headers across APIs and output
- adjust reports and tests for new header format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71d7d495883269b91eafec0bf1851