### PR TITLE
Use discovery access endpoint in unique identities

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -444,7 +444,7 @@ def discovery_runs(disco, args, dir):
         for row in rows:
             row.insert(0, args.target)
             for idx, field in enumerate(header[1:], start=1):
-                if field in int_fields:
+                if field.split(".")[-1] in int_fields:
                     try:
                         row[idx] = int(row[idx])
                     except (ValueError, TypeError):

--- a/core/builder.py
+++ b/core/builder.py
@@ -734,7 +734,7 @@ def unique_identities(search, include_endpoints=None, endpoint_prefix=None):
             logger.warning("Unexpected discovery access entry: %r", da)
             continue
             
-        endpoint = da.get("ip")
+        endpoint = da.get("DiscoveryAccess.endpoint")
         if endpoint and endpoint not in endpoint_map:
             logger.debug("Unique Endpoint: %s", endpoint)
             endpoint_map[endpoint] = {"ips": set(), "names": set()}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -190,7 +190,7 @@ def test_discovery_runs_emits_ints_and_headers(monkeypatch):
     ]
     assert captured["rows"] == [["appl", 1, 2, "r1", 3, 4]]
     row = captured["rows"][0]
-    for index in [2, 3, 4, 5]:
+    for index in [1, 2, 4, 5]:
         assert isinstance(row[index], int)
 
 def test_get_outposts_uses_deleted_false():

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -425,7 +425,10 @@ def test_unique_identities_merges_device_data(monkeypatch):
             "DeviceInfo.sysname": "host2",
         },
     ]
-    da_results = [{"ip": "10.0.0.1"}, {"ip": "10.0.0.2"}]
+    da_results = [
+        {"DiscoveryAccess.endpoint": "10.0.0.1"},
+        {"DiscoveryAccess.endpoint": "10.0.0.2"},
+    ]
 
     seq = iter([devices, da_results])
     monkeypatch.setattr(builder.api, "search_results", lambda *a, **k: next(seq))

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -88,8 +88,76 @@ def test_device_ids_report_includes_coverage(monkeypatch):
         name="device_ids",
     )
 
+    assert captured["data"]
     assert captured["headers"][-1] == "Coverage %"
     assert captured["data"][0][-1] == 50.0
+
+
+def test_unique_identities_uses_da_endpoint(monkeypatch):
+    monkeypatch.setattr(builder.tools, "completage", lambda *a, **k: 0)
+    seq = iter([[], [{"DiscoveryAccess.endpoint": "10.0.0.1"}]])
+    monkeypatch.setattr(builder.api, "search_results", lambda *a, **k: next(seq))
+
+    result = builder.unique_identities(None)
+
+    assert result == [
+        {
+            "originating_endpoint": "10.0.0.1",
+            "list_of_ips": [],
+            "list_of_names": [],
+            "coverage_pct": 0.0,
+        }
+    ]
+
+
+def test_devices_report_contains_data(monkeypatch):
+    identities = [
+        {
+            "originating_endpoint": "1.1.1.1",
+            "list_of_ips": ["1.1.1.1"],
+            "list_of_names": ["host"],
+        }
+    ]
+    result = [
+        {
+            "DiscoveryAccess.endpoint": "1.1.1.1",
+            "DeviceInfo.hostname": "host",
+            "DiscoveryAccess.starttime": "2024-01-01 00:00:00 UTC",
+            "DiscoveryRun.label": "run1",
+            "DeviceInfo.last_credential": "cred-uuid",
+            "DiscoveryAccess.result": "ok",
+            "DiscoveryAccess.end_state": "finished",
+            "DeviceInfo.kind": "server",
+            "DeviceInfo.last_access_method": "ssh",
+        }
+    ]
+    monkeypatch.setattr(reporting.builder, "unique_identities", lambda *a, **k: identities)
+    monkeypatch.setattr(reporting.api, "search_results", lambda *a, **k: result)
+    monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.tools, "get_credential", lambda *a, **k: {"label": "cred1", "username": "user1"})
+    monkeypatch.setattr(reporting.tools, "list_of_lists", lambda *a, **k: a[2])
+    monkeypatch.setattr(reporting.tools, "sortlist", lambda l, dv=None: l)
+
+    captured = {}
+
+    def fake_report(data, headers, args, name=None):
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["name"] = name
+
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=fake_report))
+
+    args = types.SimpleNamespace(
+        output_csv=False,
+        output_file=None,
+        include_endpoints=None,
+        endpoint_prefix=None,
+    )
+
+    reporting.devices(DummySearch(), DummyCreds(), args)
+
+    assert captured["name"] == "devices"
+    assert captured["data"]
 
 
 def test_discovery_access_handles_bad_api(monkeypatch):


### PR DESCRIPTION
## Summary
- use `DiscoveryAccess.endpoint` when computing unique identities
- add tests for device and device_ids reporting and endpoint sourcing
- ensure discovery run metrics cast numeric fields correctly

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a756b6d0ac8326aa5fb560dd2111eb