### PR TITLE
Avoid SyntaxWarning in audit query and test for clean import

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -348,7 +348,7 @@ orphan_vms = """
                     vm_class
                 """
 
-audit = """
+audit = r"""
             search in 'Audit' UserEventAuditRecord
             where not (user matches '^\[\w+\]$')
             show

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+import warnings
+
+
+def test_queries_import_no_warnings(recwarn):
+    """Import core.queries and ensure no warnings are emitted."""
+    warnings.simplefilter("always")
+    sys.modules.pop("core.queries", None)
+    importlib.import_module("core.queries")
+    assert len(recwarn) == 0


### PR DESCRIPTION
## Summary
- prefix `audit` query string with `r` to avoid Python `SyntaxWarning`
- add test ensuring importing `core.queries` emits no warnings

## Testing
- `python3 -m pytest tests/test_queries.py`


------
https://chatgpt.com/codex/tasks/task_e_68a756c582648326b375791aa51da8a0