### PR TITLE
Validate orphan VM response type and add test

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -440,7 +440,12 @@ def discovery_runs(disco, args, dir):
         logger.debug('Runs:\n%s' % r)
         header, rows, _ = tools.json2csv(runs)
         header.insert(0, "Discovery Instance")
-        int_fields = {"done", "pre_scanning", "scanning", "total"}
+        int_fields = {
+            "DiscoveryRun.done",
+            "DiscoveryRun.pre_scanning",
+            "DiscoveryRun.scanning",
+            "DiscoveryRun.total",
+        }
         for row in rows:
             row.insert(0, args.target)
             for idx, field in enumerate(header[1:], start=1):
@@ -670,6 +675,14 @@ def host_util(search, args, dir):
 @output._timer("Orphan VMs")
 def orphan_vms(search, args, dir):
     results = search_results(search, queries.orphan_vms)
+    if not isinstance(results, list) or not all(isinstance(r, dict) for r in results):
+        logger.error(
+            "Unexpected search results type for orphan_vms: %s",
+            type(results).__name__,
+        )
+        output.csv_file([], [], dir + defaults.orphan_vms_filename)
+        return
+
     headers = []
     rows = []
     for r in results or []:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -190,7 +190,7 @@ def test_discovery_runs_emits_ints_and_headers(monkeypatch):
     ]
     assert captured["rows"] == [["appl", 1, 2, "r1", 3, 4]]
     row = captured["rows"][0]
-    for index in [2, 3, 4, 5]:
+    for index in [1, 2, 4, 5]:
         assert isinstance(row[index], int)
 
 def test_get_outposts_uses_deleted_false():

--- a/tests/test_orphan_vms.py
+++ b/tests/test_orphan_vms.py
@@ -88,3 +88,30 @@ def test_cli_orphan_vms_includes_os_type(monkeypatch):
     assert "DeviceInfo.os_type" in captured["query"]
     assert "OS_Type" in captured["header"]
 
+
+def test_api_orphan_vms_handles_non_list_response(monkeypatch):
+    captured = {}
+
+    def fake_search_results(search, query):
+        return {"error": "bad"}
+
+    def fake_csv_file(data, header, filename):
+        captured["data"] = data
+        captured["header"] = header
+
+    monkeypatch.setattr(api_mod, "search_results", fake_search_results)
+    monkeypatch.setattr(api_mod.output, "csv_file", fake_csv_file)
+
+    args = types.SimpleNamespace(
+        output_file=None,
+        output_csv=None,
+        output_null=False,
+        output_cli=False,
+        target="t",
+    )
+
+    api_mod.orphan_vms(DummySearch(), args, "")
+
+    assert captured["data"] == []
+    assert captured["header"] == []
+


### PR DESCRIPTION
## Summary
- ensure `orphan_vms` gracefully handles non-list search results by logging and writing an empty CSV
- fix integer field handling for `discovery_runs`
- test `orphan_vms` for unexpected responses and adjust discovery run test to check numeric columns

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a756ca33b08326baee348321821420