### PR TITLE
docs: add AGENTS instructions for junior-friendly code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
-# Project Agents.md Guide for OpenAI Codex
+# Project AGENTS Guide for OpenAI Codex
 
-This `agents.md` file provides comprehensive guidance for OpenAI Codex and other AI agents contributing to the **DisMAL** codebase.
+This `AGENTS.md` file provides guidance for OpenAI Codex and other AI agents contributing to the **DisMAL** codebase.
 
 DisMAL (Discovery-Mod-And-Lookup Toolkit) is a CLI-based Python tool for interacting with BMC Discovery appliances via API or CLI.
 
 ---
 
-## Project Structure for OpenAI Codex Navigation
+## Project Structure
 
 - `/core`: Primary source code for data access, command dispatch, and output formatting
 - `/bin`: CLI entry points and scripts
@@ -21,20 +21,21 @@ Agents must avoid modifying:
 
 ---
 
-## Coding Conventions for OpenAI Codex
+## Coding Conventions
 
-### General Python Conventions
+### General Python
 
 - Use **Python 3.8+** compatible syntax
 - Follow **PEP8** style guide unless local conventions differ
 - Prefer built-in libraries (`argparse`, `subprocess`, `requests`) unless justified
 - Use **meaningful function and variable names**
 - Include **inline comments** for any logic branches, string parsing, or regex
+- Write code that a junior developer can easily read and understand
 
 ### CLI-Specific Guidance
 
 - All CLI commands are defined and dispatched in `dismal.py` using `argparse`
-- Agents should preserve subcommand structure and `--access_method` logic
+- Preserve subcommand structure and `--access_method` logic
 - Add new subcommands only if tested and scoped appropriately
 
 ### Output and File Writing
@@ -44,7 +45,13 @@ Agents must avoid modifying:
 
 ---
 
-## Testing Requirements for OpenAI Codex
+## Branch Policy
+
+- Perform code changes on the `codex` branch. If the branch is unavailable or you are on a different branch, warn the maintainer before proceeding.
+
+---
+
+## Testing Requirements
 
 Tests should be created and maintained under `/tests` and follow these conventions:
 
@@ -57,3 +64,4 @@ python3 -m pytest tests/test_access.py
 
 # Generate coverage report
 coverage run -m pytest && coverage report
+```


### PR DESCRIPTION
## Summary
- add AGENTS.md with guidance for junior developers
- document branch policy to work on `codex`

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac88386bf88326b95f636fa81aa23d