### PR TITLE
Add query support for active discovery runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ compared to the total endpoints examined.
 
 The toolkit now offers a broad range of reports. Selected examples include:
 
+- **active_runs** – list active Discovery Runs; add `--queries` to run via search query.
 - **credential_success** – report on credential success with totals and success percentages.
 - **device_ids** – list unique device identities with a Guide % for each originating endpoint.
 - **devices** – summarize unique device profiles with last access and credential details.

--- a/core/queries.py
+++ b/core/queries.py
@@ -137,6 +137,17 @@ scanrange = {
                 recurrenceDescription(schedule) as 'Date_Rules'
                 """
                }
+active_runs = """
+                    search DiscoveryRun where not endtime
+                    show
+                    run_id as 'DiscoveryRun.run_id',
+                    status as 'DiscoveryRun.status',
+                    range_id as 'DiscoveryRun.range_id',
+                    total as 'DiscoveryRun.total',
+                    scanning as 'DiscoveryRun.scanning',
+                    pre_scanning as 'DiscoveryRun.pre_scanning',
+                    done as 'DiscoveryRun.done'
+                """
 last_disco = {
             "query":"""
                     search DiscoveryAccess where endtime

--- a/dismal.py
+++ b/dismal.py
@@ -138,7 +138,7 @@ excavation.add_argument('--excavate', dest='excavate', type=str, required=False,
 Excavation reports - for automated beneficial reporting and deeper analysis.
 Providing no <report> or using "default" will run all options that do not require a value.
 \nOptions:
-"active_runs"               - List active Discovery Runs
+"active_runs"               - List active Discovery Runs (use --queries for query output)
 "credential_success"        - Report on credential success with total number of accesses, success %% and ranges
 "db_lifecycle"              - Export Database lifecycle report
 "device" <name>             - Report on a specific device node by name (Host, NetworkDevice, Printer, SNMPManagedDevice, StorageDevice, ManagementController)


### PR DESCRIPTION
## Summary
- add `active_runs` query to mirror API-based active run output
- document `--excavate active_runs` support for `--queries`

## Testing
- `pip install -r requirements-dev.txt -r requirements.txt`
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac90352c3c832691745fb75f915565