### PR TITLE
Run all report queries with --queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,6 @@ python3 dismal.py --access_method api -i <appliance> -u <user> -p <password> \
     --excavate credential_success --queries
 ```
 
-The example above writes `qry_credential_success.csv` to the output
+The example above writes one CSV for each underlying query (for example,
+`qry_credential_success.csv` and `qry_deviceinfo_success.csv`) to the output
 directory for further analysis.

--- a/core/api.py
+++ b/core/api.py
@@ -1179,6 +1179,19 @@ def search_results(api_endpoint, query):
             )
         return []
 
+REPORT_QUERY_MAP = {
+    "credential_success": [
+        "credential_success",
+        "deviceinfo_success",
+        "credential_failure",
+        "credential_success_7d",
+        "deviceinfo_success_7d",
+        "credential_failure_7d",
+        "scanrange",
+        "excludes",
+    ]
+}
+
 def run_queries(search, args, dir):
     """Execute queries from :mod:`core.queries` without post-processing.
 
@@ -1190,25 +1203,26 @@ def run_queries(search, args, dir):
 
     names = getattr(args, "excavate", []) or []
     for name in names:
-        query = getattr(queries, name, None)
-        if query is None:
-            msg = f"Query '{name}' not found"
-            print(msg)
-            logger.error(msg)
-            continue
+        for qname in REPORT_QUERY_MAP.get(name, [name]):
+            query = getattr(queries, qname, None)
+            if query is None:
+                msg = f"Query '{qname}' not found"
+                print(msg)
+                logger.error(msg)
+                continue
 
-        filename = os.path.join(dir, f"qry_{name}.csv")
-        # Use the "query" output type so ``define_csv`` handles the API call
-        # and CSV conversion for us without additional processing.
-        output.define_csv(
-            args,
-            search,
-            query,
-            filename,
-            getattr(args, "output_file", None),
-            getattr(args, "target", None),
-            "query",
-        )
+            filename = os.path.join(dir, f"qry_{qname}.csv")
+            # Use the "query" output type so ``define_csv`` handles the API call
+            # and CSV conversion for us without additional processing.
+            output.define_csv(
+                args,
+                search,
+                query,
+                filename,
+                getattr(args, "output_file", None),
+                getattr(args, "target", None),
+                "query",
+            )
 
 def hostname(args,dir):
     output.define_txt(args,args.target,os.path.join(dir, defaults.hostname_filename),None)

--- a/core/queries.py
+++ b/core/queries.py
@@ -197,6 +197,17 @@ ip_schedules = """search DiscoveryAccess
                     nodecount(traverse Member:List:List:DiscoveryRun where scan_type = 'Scheduled') as 'schedules'
                     process with unique()"""
 
+active_runs = """
+                    search DiscoveryRun where status != 'Finished'
+                    show run_id as 'DiscoveryRun.run_id',
+                         status as 'DiscoveryRun.status',
+                         range_id as 'DiscoveryRun.range_id',
+                         total as 'DiscoveryRun.total',
+                         scanning as 'DiscoveryRun.scanning',
+                         pre_scanning as 'DiscoveryRun.pre_scanning',
+                         done as 'DiscoveryRun.done'
+                """
+
 connections_unscanned = """
                     search Host
                     traverse InferredElement:Inference:Associate:DiscoveryAccess

--- a/dismal.py
+++ b/dismal.py
@@ -184,7 +184,8 @@ excavation.add_argument(
     dest='queries',
     action='store_true',
     required=False,
-    help='Run specified --excavate items as raw queries and export CSV results without post-processing.',
+    help=('Run specified --excavate items as raw queries and export CSV results without '
+          'post-processing. Each query is saved to a separate file prefixed with qry_.'),
 )
 
 excavation.add_argument(


### PR DESCRIPTION
## Summary
- map credential_success excavation to its underlying queries and export each to `qry_*.csv`
- add `active_runs` query for raw export
- clarify CLI help and docs around `--queries`

## Testing
- `pip install pyyaml`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f9e8dd4832685b9cef376f4a7aa