### PR TITLE
Refactor active_runs query to avoid inequality operators

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -137,17 +137,6 @@ scanrange = {
                 recurrenceDescription(schedule) as 'Date_Rules'
                 """
                }
-active_runs = """
-                    search DiscoveryRun where not endtime
-                    show
-                    run_id as 'DiscoveryRun.run_id',
-                    status as 'DiscoveryRun.status',
-                    range_id as 'DiscoveryRun.range_id',
-                    total as 'DiscoveryRun.total',
-                    scanning as 'DiscoveryRun.scanning',
-                    pre_scanning as 'DiscoveryRun.pre_scanning',
-                    done as 'DiscoveryRun.done'
-                """
 last_disco = {
             "query":"""
                     search DiscoveryAccess where endtime
@@ -209,7 +198,7 @@ ip_schedules = """search DiscoveryAccess
                     process with unique()"""
 
 active_runs = """
-                    search DiscoveryRun where status != 'Finished'
+                    search DiscoveryRun where not endtime
                     show run_id as 'DiscoveryRun.run_id',
                          status as 'DiscoveryRun.status',
                          range_id as 'DiscoveryRun.range_id',


### PR DESCRIPTION
## Summary
- Consolidate `active_runs` query definition and filter by `not endtime`
- Drop unsupported `!=` comparison from queries

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac93f25c7483268e79a55baf193509