### PR TITLE
Add query uniqueness tests and sanitize active_runs query

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -137,17 +137,6 @@ scanrange = {
                 recurrenceDescription(schedule) as 'Date_Rules'
                 """
                }
-active_runs = """
-                    search DiscoveryRun where not endtime
-                    show
-                    run_id as 'DiscoveryRun.run_id',
-                    status as 'DiscoveryRun.status',
-                    range_id as 'DiscoveryRun.range_id',
-                    total as 'DiscoveryRun.total',
-                    scanning as 'DiscoveryRun.scanning',
-                    pre_scanning as 'DiscoveryRun.pre_scanning',
-                    done as 'DiscoveryRun.done'
-                """
 last_disco = {
             "query":"""
                     search DiscoveryAccess where endtime
@@ -209,7 +198,7 @@ ip_schedules = """search DiscoveryAccess
                     process with unique()"""
 
 active_runs = """
-                    search DiscoveryRun where status != 'Finished'
+                    search DiscoveryRun where status <> 'Finished'
                     show run_id as 'DiscoveryRun.run_id',
                          status as 'DiscoveryRun.status',
                          range_id as 'DiscoveryRun.range_id',

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,6 +1,18 @@
+import ast
 import importlib
 import sys
 import warnings
+from pathlib import Path
+
+
+def _collect_query_strings(mod):
+    """Yield query strings from the queries module."""
+    for name in dir(mod):
+        value = getattr(mod, name)
+        if isinstance(value, str):
+            yield value
+        elif isinstance(value, dict) and isinstance(value.get("query"), str):
+            yield value["query"]
 
 
 def test_queries_import_no_warnings(recwarn):
@@ -9,3 +21,24 @@ def test_queries_import_no_warnings(recwarn):
     sys.modules.pop("core.queries", None)
     importlib.import_module("core.queries")
     assert len(recwarn) == 0
+
+
+def test_queries_unique_variable_names():
+    """Ensure each variable in core/queries.py is defined only once."""
+    path = Path("core/queries.py")
+    tree = ast.parse(path.read_text())
+    names = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.append(target.id)
+    duplicates = {n for n in names if names.count(n) > 1}
+    assert not duplicates, f"Duplicate variable names found: {duplicates}"
+
+
+def test_queries_no_unsupported_characters():
+    """Validate each query string contains no unsupported characters."""
+    mod = importlib.import_module("core.queries")
+    for query in _collect_query_strings(mod):
+        assert "!" not in query, "Unsupported character '!' found in query"


### PR DESCRIPTION
## Summary
- test queries module for duplicate variable names
- validate queries against unsupported characters
- remove duplicate `active_runs` query and avoid `!` usage

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac93f580cc8326a534945d0ca00ea8