### PR TITLE
Remove __had_inference filter from DeviceInfo success queries

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -267,7 +267,7 @@ def ordering(creds, search, args, apply):
                                         show (slave or credential) as cred_uuid, session_type process with countUnique(0)
                                         """ % (cred['uuid'],cred['uuid']))
         devinfosux = api.search_results(search,"""
-                                        search DeviceInfo where method_success and __had_inference
+                                        search DeviceInfo where method_success
                                         and (slave = "%s" or credential = "%s")
                                         and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
                                         show (last_credential or last_slave) as cred_uuid,

--- a/core/queries.py
+++ b/core/queries.py
@@ -13,7 +13,7 @@ credential_failure = """
                             processwith countUnique(1,0)
                         """
 deviceinfo_success = """
-                          search DeviceInfo where method_success and __had_inference
+                          search DeviceInfo where method_success
                           and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess
                                             traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
                           show (last_credential or last_slave) as 'DeviceInfo.last_credential',
@@ -33,7 +33,7 @@ credential_failure_7d = """
                             processwith countUnique(1,0)
                         """
 deviceinfo_success_7d = """
-                          search DeviceInfo where method_success and __had_inference
+                          search DeviceInfo where method_success
                           and nodecount(traverse DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess
                                             traverse DiscoveryAccess:Metadata:Detail:SessionResult) = 0
                           and time_index > (currentTime() - 7*24*3600*10000000)


### PR DESCRIPTION
## Summary
- remove `__had_inference` from DeviceInfo success queries
- align credential weighting query with updated DeviceInfo filter

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac92c513fc832689e7eeabf9a994ec