### PR TITLE
Handle prefixed credential paths in session lookups

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -162,54 +162,29 @@ def successful(creds, search, args):
         session = None
         percent_all = 0.0
         percent7 = 0.0
-        failure = [None, 0]
-        sessions = [None, 0]
-        devinfos = [None, 0]
-        failure7 = [None, 0]
-        sessions7 = [None, 0]
-        devinfos7 = [None, 0]
-        try:
-            sessions = suxCreds[uuid]
-            active = True
-            msg = "Sessions found, Active: %s" % sessions
-            logger.debug(msg)
-        except KeyError:
-            pass
-        try:
-            devinfos = suxDev[uuid]
-            active = True
-            msg = "DeviceInfos found, Active: %s" % devinfos
-            logger.debug(msg)
-        except KeyError:
-            pass
-        try:
-            failure = failCreds[uuid]
-            active = True
-            msg = "Failures found, Active: %s" % failure
-            logger.debug(msg)
-        except KeyError:
-            pass
-        try:
-            sessions7 = suxCreds7[uuid]
-            active = True
-            msg = "Sessions 7d found, Active: %s" % sessions7
-            logger.debug(msg)
-        except KeyError:
-            pass
-        try:
-            devinfos7 = suxDev7[uuid]
-            active = True
-            msg = "DeviceInfos 7d found, Active: %s" % devinfos7
-            logger.debug(msg)
-        except KeyError:
-            pass
-        try:
-            failure7 = failCreds7[uuid]
-            active = True
-            msg = "Failures 7d found, Active: %s" % failure7
-            logger.debug(msg)
-        except KeyError:
-            pass
+
+        # Look up success/failure information for this credential
+        sessions = suxCreds.get(uuid)
+        devinfos = suxDev.get(uuid)
+        failure = failCreds.get(uuid)
+        sessions7 = suxCreds7.get(uuid)
+        devinfos7 = suxDev7.get(uuid)
+        failure7 = failCreds7.get(uuid)
+
+        # Determine if this credential was seen in any query results, even if
+        # the count is zero
+        active = any(
+            record is not None
+            for record in [sessions, devinfos, failure, sessions7, devinfos7, failure7]
+        )
+
+        # Replace missing entries with default zero counts for later math
+        sessions = sessions or [None, 0]
+        devinfos = devinfos or [None, 0]
+        failure = failure or [None, 0]
+        sessions7 = sessions7 or [None, 0]
+        devinfos7 = devinfos7 or [None, 0]
+        failure7 = failure7 or [None, 0]
 
         if sessions[0] and devinfos[0]:
             seshcount = int(sessions[1])

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -452,6 +452,88 @@ def test_successful_includes_outpost_credentials(monkeypatch):
     assert captured["row"][-1] == "http://op"
 
 
+def test_successful_handles_prefixed_credential_paths(monkeypatch):
+    """Query results may return object-path prefixes on credential fields."""
+
+    def fake_search_results(search, query):
+        if query is reporting.queries.credential_success:
+            return [
+                {
+                    "SessionResult.slave_or_credential": "Credential/u1",
+                    "SessionResult.session_type": "ssh",
+                    "Count": 2,
+                }
+            ]
+        if query is reporting.queries.deviceinfo_success:
+            return [
+                {
+                    "DeviceInfo.last_credential": "Credential/u1",
+                    "DeviceInfo.access_method": "ssh",
+                    "Count": 3,
+                }
+            ]
+        if query is reporting.queries.credential_failure:
+            return [
+                {
+                    "SessionResult.slave_or_credential": "Credential/u1",
+                    "SessionResult.session_type": "ssh",
+                    "Count": 4,
+                }
+            ]
+        return []
+
+    call = {"n": 0}
+
+    def fake_get_json(*a, **k):
+        call["n"] += 1
+        if call["n"] == 1:
+            return [
+                {
+                    "uuid": "u1",
+                    "label": "c",
+                    "index": 1,
+                    "enabled": True,
+                    "username": "user",
+                    "usage": "",
+                    "iprange": None,
+                    "exclusions": None,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(reporting.api, "get_json", fake_get_json)
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.api, "get_outpost_credential_map", lambda *a, **k: {})
+    monkeypatch.setattr(reporting.builder, "get_credentials", lambda entry: entry)
+    monkeypatch.setattr(reporting.builder, "get_scans", lambda *a, **k: [])
+
+    captured = {}
+
+    def fake_report(data, headers, args, name=""):
+        captured["row"] = data[0]
+        captured["headers"] = headers
+
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=fake_report))
+
+    args = types.SimpleNamespace(
+        output_csv=False,
+        output_file=None,
+        token=None,
+        target="http://x",
+        include_endpoints=None,
+        endpoint_prefix=None,
+    )
+
+    reporting.successful(DummyCreds(), DummySearch(), args)
+
+    headers = captured["headers"]
+    row = captured["row"]
+    idx_s = headers.index("Successes")
+    idx_f = headers.index("Failures")
+    assert row[idx_s] == 5
+    assert row[idx_f] == 4
+
+
 def test_successful_uses_token_file(monkeypatch, tmp_path):
     file_path = tmp_path / "token.txt"
     file_path.write_text("abc")


### PR DESCRIPTION
## Summary
- expand `session_get` to handle `DeviceInfo.last_credential` and strip object-path prefixes
- treat zero-count lookup data as active in `reporting.successful`
- add regression test for prefixed credential paths in reporting

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f8209e08326aeda2464640329f2