### PR TITLE
Rename active runs report to active scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ compared to the total endpoints examined.
 
 The toolkit now offers a broad range of reports. Selected examples include:
 
-- **active_runs** – list active Discovery Runs; add `--queries` to run via search query.
+- **active_scans** – list active Discovery Runs; add `--queries` to run via search query.
 - **credential_success** – report on credential success with totals and success percentages.
 - **device_ids** – list unique device identities with a Guide % for each originating endpoint.
 - **devices** – summarize unique device profiles with last access and credential details.

--- a/core/queries.py
+++ b/core/queries.py
@@ -197,7 +197,7 @@ ip_schedules = """search DiscoveryAccess
                     nodecount(traverse Member:List:List:DiscoveryRun where scan_type = 'Scheduled') as 'schedules'
                     process with unique()"""
 
-active_runs = """
+active_scans = """
                     search DiscoveryRun where not endtime
                     show run_id as 'DiscoveryRun.run_id',
                          status as 'DiscoveryRun.status',

--- a/dismal.py
+++ b/dismal.py
@@ -138,7 +138,7 @@ excavation.add_argument('--excavate', dest='excavate', type=str, required=False,
 Excavation reports - for automated beneficial reporting and deeper analysis.
 Providing no <report> or using "default" will run all options that do not require a value.
 \nOptions:
-"active_runs"               - List active Discovery Runs (use --queries for query output)
+"active_scans"              - List active Discovery Runs (use --queries for query output)
 "credential_success"        - Report on credential success with total number of accesses, success %% and ranges
 "db_lifecycle"              - Export Database lifecycle report
 "device" <name>             - Report on a specific device node by name (Host, NetworkDevice, Printer, SNMPManagedDevice, StorageDevice, ManagementController)
@@ -726,7 +726,7 @@ def run_for_args(args):
         if excavate_default or (args.excavate and args.excavate[0] == "discovery_run_analysis"):
             reporting.discovery_run_analysis(search, creds, args)
 
-        if excavate_default or (args.excavate and args.excavate[0] == "active_runs"):
+        if excavate_default or (args.excavate and args.excavate[0] == "active_scans"):
             api.show_runs(disco, args)
             api.discovery_runs(disco, args, reporting_dir)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,7 +154,7 @@ def test_show_runs_excavate_routes_to_define_csv(monkeypatch):
 
     reporting_dir = "/tmp"
     args = types.SimpleNamespace(
-        excavate=["active_runs"], reporting_dir=reporting_dir, target="appl"
+        excavate=["active_scans"], reporting_dir=reporting_dir, target="appl"
     )
 
     show_runs(disco, args)
@@ -177,7 +177,7 @@ def test_show_runs_excavate_default_dir(monkeypatch):
 
     monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
 
-    args = types.SimpleNamespace(excavate=["active_runs"])
+    args = types.SimpleNamespace(excavate=["active_scans"])
 
     show_runs(disco, args)
 
@@ -246,15 +246,15 @@ def test_run_queries_executes_named_query(monkeypatch, tmp_path):
     monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
 
     args = types.SimpleNamespace(
-        excavate=["active_runs"], output_file=None, target="appl"
+        excavate=["active_scans"], output_file=None, target="appl"
     )
     search = object()
     outdir = str(tmp_path)
 
     api_mod.run_queries(search, args, outdir)
 
-    assert recorded["query"] == api_mod.queries.active_runs
-    expected = os.path.join(outdir, "qry_active_runs.csv")
+    assert recorded["query"] == api_mod.queries.active_scans
+    expected = os.path.join(outdir, "qry_active_scans.csv")
     assert recorded["path"] == expected
     assert recorded["type"] == "query"
 


### PR DESCRIPTION
## Summary
- rename active_runs excavation report to active_scans
- update query name and generated CSV filenames
- adjust documentation and tests for active_scans

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acabb1616883269b431b7b78055386