### PR TITLE
Normalize credential UUID handling in sessions and reporting

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -170,6 +170,11 @@ def successful(creds, search, args):
         detail = builder.get_credentials(cred)
 
         uuid = detail.get('uuid')
+        if uuid is not None:
+            # Mirror the normalization performed in ``tools.session_get`` so
+            # that dictionary lookups are case-insensitive and unaffected by
+            # object-path prefixes such as "Credential/".
+            uuid = str(uuid).split('/')[-1].lower()
         msg = "Working UUID :%s\n"%uuid
         logger.debug(msg)
         # Ensure index is numeric for downstream calculations

--- a/core/tools.py
+++ b/core/tools.py
@@ -179,9 +179,11 @@ def session_get(results):
         )
 
         if uuid:
-            # Remove any object-path prefixes and keep only the raw UUID
-            if isinstance(uuid, str):
-                uuid = uuid.split("/")[-1]
+            # Normalize credential identifiers: drop any object-path prefixes
+            # and perform case-insensitive comparisons by storing the UUID in
+            # lowercase. Casting to ``str`` also protects against UUID objects
+            # from third-party libraries.
+            uuid = str(uuid).split("/")[-1].lower()
             sessions[uuid] = [restype, count]
 
     return sessions

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -655,14 +655,14 @@ def test_successful_shows_zero_percent_when_no_success_7d(monkeypatch):
     assert row[headers.index("Success % 7 Days")] == 0
 
 
-def test_successful_handles_prefixed_credential_paths(monkeypatch):
-    """Query results may return object-path prefixes on credential fields."""
+def test_successful_handles_prefixed_and_mixed_case_credential_paths(monkeypatch):
+    """Query results may return object-path prefixes and mixed-case UUIDs."""
 
     def fake_search_results(search, query):
         if query is reporting.queries.credential_success:
             return [
                 {
-                    "SessionResult.slave_or_credential": "Credential/u1",
+                    "SessionResult.slave_or_credential": "Credential/U1",
                     "SessionResult.session_type": "ssh",
                     "Count": 2,
                 }
@@ -670,7 +670,7 @@ def test_successful_handles_prefixed_credential_paths(monkeypatch):
         if query is reporting.queries.deviceinfo_success:
             return [
                 {
-                    "DeviceInfo.last_credential": "Credential/u1",
+                    "DeviceInfo.last_credential": "Credential/U1",
                     "DeviceInfo.access_method": "ssh",
                     "Count": 3,
                 }
@@ -678,7 +678,7 @@ def test_successful_handles_prefixed_credential_paths(monkeypatch):
         if query is reporting.queries.credential_failure:
             return [
                 {
-                    "SessionResult.slave_or_credential": "Credential/u1",
+                    "SessionResult.slave_or_credential": "Credential/U1",
                     "SessionResult.session_type": "ssh",
                     "Count": 4,
                 }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -55,3 +55,14 @@ def test_session_get_falls_back_to_uuid():
         }
     ]
     assert tools.session_get(results) == {"u1": ["ssh", 1]}
+
+
+def test_session_get_normalizes_uuid_case():
+    results = [
+        {
+            "uuid": "Credential/ABCDEF",
+            "SessionResult.session_type": "ssh",
+            "Count": "1",
+        }
+    ]
+    assert tools.session_get(results) == {"abcdef": ["ssh", 1]}


### PR DESCRIPTION
## Summary
- Normalize UUID strings in `session_get` to strip path prefixes and convert to lowercase
- Normalize credential UUIDs in reporting's success loop to ensure consistent lookups
- Add regression tests for mixed-case, prefixed UUIDs in tools and reporting helpers

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acc09836c48326b95e89dceb3a4340