### PR TITLE
Add debug logging for credential activity and 7-day success metrics

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -225,6 +225,7 @@ def successful(creds, search, args):
                 failCreds7,
             ]
         )
+        logger.debug("UUID %s -> active=%s", uuid, active)
 
         if sessions[0] and devinfos[0]:
             success_all = int(sessions[1]) + int(devinfos[1])
@@ -246,10 +247,17 @@ def successful(creds, search, args):
 
         if sessions7[0] and devinfos7[0]:
             success7 = int(sessions7[1]) + int(devinfos7[1])
+            logger.debug(
+                "UUID %s -> success7=%s (sessions7 + devinfos7)", uuid, success7
+            )
         elif sessions7[0]:
             success7 = int(sessions7[1])
+            logger.debug("UUID %s -> success7=%s (sessions7 only)", uuid, success7)
         elif devinfos7[0]:
             success7 = int(devinfos7[1])
+            logger.debug("UUID %s -> success7=%s (devinfos7 only)", uuid, success7)
+        else:
+            logger.debug("UUID %s -> success7=%s (no data)", uuid, success7)
 
         scheduled_scans = builder.get_scans(scan_ranges_results, list_of_ranges)
         msg = "Scheduled Scans List" % scheduled_scans


### PR DESCRIPTION
## Summary
- log whether each credential appears in any success/failure mapping
- log how 7-day success counts are derived from session and device-info data

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbfef4000832696f716b609f4c73b