### PR TITLE
fix: prefer credential id for success metrics

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -2,13 +2,13 @@
 
 credential_success = """
                             search SessionResult where success
-                            show (slave or credential) as 'UUID',
+                            show (credential or slave) as 'UUID',
                             session_type as 'Session_Type'
                             processwith countUnique(1,0)
                         """
 credential_failure = """
                             search SessionResult where not success
-                            show (slave or credential) as 'UUID',
+                            show (credential or slave) as 'UUID',
                             session_type as 'Session_Type'
                             processwith countUnique(1,0)
                         """

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -41,6 +41,12 @@ def _run_with_patches(monkeypatch, func):
     assert "ran" in called
 
 
+def test_queries_prioritize_credential_over_slave():
+    """Ensure credential UUIDs are preferred over slave IDs in queries."""
+    assert "(credential or slave)" in reporting.queries.credential_success
+    assert "(credential or slave)" in reporting.queries.credential_failure
+
+
 def test_discovery_access_handles_bad_api(monkeypatch):
     _run_with_patches(monkeypatch, reporting.discovery_access)
 


### PR DESCRIPTION
## Summary
- ensure credential-based lookups for SessionResult queries
- guard against regressions in query structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acc963c4d88326a2fe9cc0f7482de1