### PR TITLE
Include outpost ID in credential reports

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -291,7 +291,14 @@ def get_outposts(appliance):
 
 
 def map_outpost_credentials(appliance):
-    """Return mapping of credential UUIDs to outpost URLs."""
+    """Return mapping of credential UUIDs to outpost details.
+
+    The returned dictionary maps a credential UUID to a dictionary containing
+    the outpost ``id`` (if available) and ``url``.  This provides callers with
+    enough information to reference both the outpost identifier and its
+    location.
+    """
+
     mapping = {}
     outposts = get_outposts(appliance)
     if not isinstance(outposts, list):
@@ -319,7 +326,8 @@ def map_outpost_credentials(appliance):
                 if not uuid:
                     continue
                 get_json(creds_ep.get_vault_credential(uuid))
-                mapping[uuid] = url
+                outpost_id = outpost.get("id") or outpost.get("uuid")
+                mapping[uuid] = {"id": outpost_id, "url": url}
         except Exception as e:  # pragma: no cover - network errors
             logger.error("Error processing outpost %s: %s", url, e)
     return mapping

--- a/core/builder.py
+++ b/core/builder.py
@@ -309,7 +309,13 @@ def ordering(creds, search, args, apply):
     if apply:
         for weighted_cred in weighted:
             logger.debug("Updating: %s" % (weighted_cred))
-            headers = ["New Index", "Credential", "Scope", "Outpost URL"]
+            headers = [
+                "New Index",
+                "Credential",
+                "Scope",
+                "Outpost ID",
+                "Outpost URL",
+            ]
             creds.update_cred(
                 weighted_cred.get("uuid"), {"index": weighted_cred.get("index")}
             )
@@ -320,6 +326,7 @@ def ordering(creds, search, args, apply):
             "Weighting",
             "New Index",
             "Scope",
+            "Outpost ID",
             "Outpost URL",
         ]
         for cred in credlist:
@@ -335,7 +342,9 @@ def ordering(creds, search, args, apply):
                     scope = cred.get("scopes") or []
                     if isinstance(scope, list):
                         scope = ", ".join(scope)
-                    url = outpost_map.get(cred.get("uuid"))
+                    op_info = outpost_map.get(cred.get("uuid"), {})
+                    op_id = op_info.get("id")
+                    url = op_info.get("url")
                     msg = "%s: Index: %s, Weight: %s, New Index: %s" % (
                         label,
                         index,
@@ -343,7 +352,7 @@ def ordering(creds, search, args, apply):
                         new_index,
                     )
                     logger.info(msg)
-                    data.append([label, index, weight, new_index, scope, url])
+                    data.append([label, index, weight, new_index, scope, op_id, url])
 
     # Refresh
     credlist = api.get_json(creds.get_vault_credentials)
@@ -358,8 +367,10 @@ def ordering(creds, search, args, apply):
         scope = cred.get("scopes") or []
         if isinstance(scope, list):
             scope = ", ".join(scope)
-        url = outpost_map.get(cred.get("uuid"))
-        data.append([index, label, scope, url])
+        op_info = outpost_map.get(cred.get("uuid"), {})
+        op_id = op_info.get("id")
+        url = op_info.get("url")
+        data.append([index, label, scope, op_id, url])
 
     if data:
         headers.insert(0, "Discovery Instance")

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -204,7 +204,9 @@ def successful(creds, search, args):
             percent = success / total
 
         msg = None
-        outpost_url = outpost_map.get(uuid)
+        op_info = outpost_map.get(uuid, {})
+        outpost_id = op_info.get("id")
+        outpost_url = op_info.get("url")
         usage = detail.get('usage')
         if args.output_file or args.output_csv:
             if active:
@@ -223,6 +225,7 @@ def successful(creds, search, args):
                     ip_exclude,
                     scheduled_scans if scheduled_scans else None,
                     excluded_scans if excluded_scans else None,
+                    outpost_id,
                     outpost_url,
                 ])
             else:
@@ -241,6 +244,7 @@ def successful(creds, search, args):
                     ip_exclude,
                     scheduled_scans if scheduled_scans else None,
                     excluded_scans if excluded_scans else None,
+                    outpost_id,
                     outpost_url,
                 ])
             headers = [
@@ -258,6 +262,7 @@ def successful(creds, search, args):
                 "Excludes",
                 "Scheduled Scans",
                 "Exclusion Lists",
+                "Outpost ID",
                 "Outpost URL",
             ]
         else:
@@ -273,6 +278,7 @@ def successful(creds, search, args):
                     percent,
                     status,
                     usage,
+                    outpost_id,
                     outpost_url,
                 ])
             else:
@@ -287,6 +293,7 @@ def successful(creds, search, args):
                     0.0,
                     "Credential appears to not be in use (%s)" % status,
                     usage,
+                    outpost_id,
                     outpost_url,
                 ])
             headers = [
@@ -300,6 +307,7 @@ def successful(creds, search, args):
                 "Success %",
                 "State",
                 "Usage",
+                "Outpost ID",
                 "Outpost URL",
             ]
     print(os.linesep,end="\r")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -168,7 +168,7 @@ def test_map_outpost_credentials_strips_scheme(monkeypatch):
     """Outpost targets should not include protocol."""
 
     def fake_get_outposts(app):
-        return [{"url": "https://op.example.com"}]
+        return [{"id": "op1", "url": "https://op.example.com"}]
 
     class DummyCreds:
         def get_vault_credentials(self):
@@ -193,12 +193,12 @@ def test_map_outpost_credentials_strips_scheme(monkeypatch):
     mapping = map_outpost_credentials(types.SimpleNamespace(token="t"))
 
     assert captured["target"] == "op.example.com"
-    assert mapping == {"u1": "https://op.example.com"}
+    assert mapping == {"u1": {"id": "op1", "url": "https://op.example.com"}}
 
 
 def test_map_outpost_credentials_skips_unreachable(monkeypatch, capsys, caplog):
     def fake_get_outposts(app):
-        return [{"url": "https://op.example.com"}]
+        return [{"id": "op1", "url": "https://op.example.com"}]
 
     called = {"outpost": False}
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -54,7 +54,11 @@ def test_ordering_inserts_instance_and_outpost(monkeypatch):
 
     monkeypatch.setattr(builder, "output", types.SimpleNamespace(report=fake_report))
     monkeypatch.setattr(builder.api, "search_results", lambda *a, **k: [])
-    monkeypatch.setattr(builder.api, "map_outpost_credentials", lambda app: {"u1": "http://op"})
+    monkeypatch.setattr(
+        builder.api,
+        "map_outpost_credentials",
+        lambda app: {"u1": {"id": "op1", "url": "http://op"}},
+    )
     monkeypatch.setattr(builder.tideway, "appliance", lambda target, token: types.SimpleNamespace(), raising=False)
     monkeypatch.setattr(
         builder.api,
@@ -70,6 +74,7 @@ def test_ordering_inserts_instance_and_outpost(monkeypatch):
     assert captured["name"] == "suggest_cred_opt"
     assert captured["headers"][0] == "Discovery Instance"
     assert "Scope" in captured["headers"]
+    assert "Outpost ID" in captured["headers"]
     assert "Outpost URL" in captured["headers"]
     assert captured["data"]
     assert captured["data"][0][0] == "appl"


### PR DESCRIPTION
## Summary
- return both outpost ID and URL in `map_outpost_credentials`
- surface outpost ID alongside URL in success and ordering reports
- cover new outpost fields with updated tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acca0668148326a9f68ad5e074e06b