### PR TITLE
Normalize session key lookups in tools.session_get

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -126,13 +126,31 @@ def list_of_lists(ci,attr,list_to_append):
     return list_to_append
 
 def session_get(results):
+    """Normalize and extract session details.
+
+    Keys from the results are normalised to lowercase so that values can be
+    accessed without relying on the original capitalisation.  Additionally,
+    multiple key variants are accepted for the UUID field to cope with the
+    different names returned by various APIs (e.g. ``credential`` or
+    ``slave``).  The function returns a mapping of UUID to a list containing
+    the session type and count.
+    """
+
     sessions = {}
     for result in results:
-        count = result.get('Count')
-        uuid = result.get('UUID')
-        restype = result.get('Session_Type')
+        # Normalise keys to lower case for consistent lookups
+        norm = {key.lower(): value for key, value in result.items()}
+
+        count = norm.get("count")
+
+        # UUID may be reported under a few different names
+        uuid = norm.get("uuid") or norm.get("credential") or norm.get("slave")
+
+        restype = norm.get("session_type")
+
         if uuid:
-            sessions[uuid] = [ restype, count ]
+            sessions[uuid] = [restype, count]
+
     return sessions
 
 def ip_or_string(value):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -75,11 +75,14 @@ def test_successful_combines_query_results(monkeypatch):
     def fake_search_results(search, query):
         calls.append(query)
         if query is reporting.queries.credential_success:
-            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 2}]
+            # standard lower-case field names
+            return [{"uuid": "u1", "session_type": "ssh", "count": 2}]
         if query is reporting.queries.deviceinfo_success:
-            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 3}]
+            # alternative key for UUID field
+            return [{"credential": "u1", "session_type": "ssh", "count": 3}]
         if query is reporting.queries.credential_failure:
-            return [{"UUID": "u1", "Session_Type": "ssh", "Count": 4}]
+            # another possible key name for UUID field
+            return [{"slave": "u1", "session_type": "ssh", "count": 4}]
         return []
 
     call = {"n": 0}


### PR DESCRIPTION
## Summary
- Normalize session result keys to lowercase and support multiple UUID key names
- Update reporting test fixtures to use normalized session data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68accc3a5ef08326b9f2d73674ba7c15