### PR TITLE
Fix credential success active detection and include outpost ID

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -264,7 +264,7 @@ def ordering(creds, search, args, apply):
         seshsux = api.search_results(search,"""
                                         search SessionResult where success
                                         and (slave = "%s" or credential = "%s")
-                                        show (slave or credential) as cred_uuid, session_type process with countUnique(0)
+                                        show (credential or slave) as cred_uuid, session_type process with countUnique(0)
                                         """ % (cred['uuid'],cred['uuid']))
         devinfosux = api.search_results(search,"""
                                         search DeviceInfo where method_success
@@ -277,7 +277,7 @@ def ordering(creds, search, args, apply):
         credfails = api.search_results(search,"""
                                         search SessionResult where not success
                                         and (slave = "%s" or credential = "%s")
-                                        show (slave or credential) as cred_uuid, session_type process with countUnique(0)
+                                        show (credential or slave) as cred_uuid, session_type process with countUnique(0)
                                     """ % (cred['uuid'],cred['uuid']))
         
         for credsux in seshsux:

--- a/core/queries.py
+++ b/core/queries.py
@@ -2,16 +2,18 @@
 
 credential_success = """
                             search SessionResult where success
-                            show (slave or credential) as 'SessionResult.slave_or_credential',
-                            (slave or credential) as 'uuid',
-                            session_type as 'SessionResult.session_type'
+                            show (credential or slave) as 'SessionResult.credential_or_slave',
+                            (credential or slave) as 'uuid',
+                            session_type as 'SessionResult.session_type',
+                            outpost as 'SessionResult.outpost'
                             processwith countUnique(1,0)
                         """
 credential_failure = """
                             search SessionResult where not success
-                            show (slave or credential) as 'SessionResult.slave_or_credential',
-                            (slave or credential) as 'uuid',
-                            session_type as 'SessionResult.session_type'
+                            show (credential or slave) as 'SessionResult.credential_or_slave',
+                            (credential or slave) as 'uuid',
+                            session_type as 'SessionResult.session_type',
+                            outpost as 'SessionResult.outpost'
                             processwith countUnique(1,0)
                         """
 deviceinfo_success = """
@@ -25,16 +27,18 @@ deviceinfo_success = """
                        """
 credential_success_7d = """
                             search SessionResult where success and time_index > (currentTime() - 7*24*3600*10000000)
-                            show (slave or credential) as 'SessionResult.slave_or_credential',
-                            (slave or credential) as 'uuid',
-                            session_type as 'SessionResult.session_type'
+                            show (credential or slave) as 'SessionResult.credential_or_slave',
+                            (credential or slave) as 'uuid',
+                            session_type as 'SessionResult.session_type',
+                            outpost as 'SessionResult.outpost'
                             processwith countUnique(1,0)
                         """
 credential_failure_7d = """
                             search SessionResult where not success and time_index > (currentTime() - 7*24*3600*10000000)
-                            show (slave or credential) as 'SessionResult.slave_or_credential',
-                            (slave or credential) as 'uuid',
-                            session_type as 'SessionResult.session_type'
+                            show (credential or slave) as 'SessionResult.credential_or_slave',
+                            (credential or slave) as 'uuid',
+                            session_type as 'SessionResult.session_type',
+                            outpost as 'SessionResult.outpost'
                             processwith countUnique(1,0)
                         """
 deviceinfo_success_7d = """

--- a/core/tools.py
+++ b/core/tools.py
@@ -132,8 +132,9 @@ def list_of_lists(ci,attr,list_to_append):
 def session_get(results):
     """Convert session/device info search results into a mapping.
 
-    Results may contain ``SessionResult.slave_or_credential``,
-    ``DeviceInfo.last_credential`` or a generic ``uuid`` field.  Any object
+    Results may contain ``SessionResult.credential_or_slave`` (or the legacy
+    ``SessionResult.slave_or_credential``), ``DeviceInfo.last_credential`` or a
+    generic ``uuid`` field.  Any object
     path prefixes are stripped so the returned dictionary uses raw credential
     UUIDs as keys.  The stored value is a two-item list of the access method and
     lookup count.
@@ -168,7 +169,8 @@ def session_get(results):
         # Accept both SessionResult and DeviceInfo credential fields, falling
         # back to a plain ``uuid`` field if neither is present.
         uuid = (
-            result.get("SessionResult.slave_or_credential")
+            result.get("SessionResult.credential_or_slave")
+            or result.get("SessionResult.slave_or_credential")
             or result.get("DeviceInfo.last_credential")
             or result.get("uuid")
         )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -271,17 +271,17 @@ def test_successful_combines_query_results(monkeypatch):
     def fake_search_results(search, query):
         calls.append(query)
         if query is reporting.queries.credential_success:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
         if query is reporting.queries.deviceinfo_success:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 3}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 3}]
         if query is reporting.queries.credential_failure:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 4}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 4}]
         if query is reporting.queries.credential_success_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         if query is reporting.queries.deviceinfo_success_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         if query is reporting.queries.credential_failure_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         return []
 
     call = {"n": 0}
@@ -343,17 +343,17 @@ def test_successful_coerces_string_counts(monkeypatch):
 
     def fake_search_results(search, query):
         if query is reporting.queries.credential_success:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "2"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "2"}]
         if query is reporting.queries.deviceinfo_success:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "3"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "3"}]
         if query is reporting.queries.credential_failure:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "4"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "4"}]
         if query is reporting.queries.credential_success_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
         if query is reporting.queries.deviceinfo_success_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
         if query is reporting.queries.credential_failure_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "1"}]
         return []
 
     call = {"n": 0}
@@ -424,7 +424,7 @@ def test_successful_emits_row_when_deviceinfo_7d_empty(monkeypatch):
         if query is reporting.queries.credential_failure_7d:
             return [
                 {
-                    "SessionResult.slave_or_credential": "u1",
+                    "SessionResult.credential_or_slave": "u1",
                     "SessionResult.session_type": "ssh",
                     "Count": 1,
                 }
@@ -553,7 +553,7 @@ def test_successful_includes_outpost_credentials(monkeypatch):
         if query is reporting.queries.credential_success:
             return [
                 {
-                    "SessionResult.slave_or_credential": "/prefix/u1",
+                    "SessionResult.credential_or_slave": "/prefix/u1",
                     "SessionResult.session_type": "ssh",
                     "Count": 2,
                 }
@@ -561,7 +561,7 @@ def test_successful_includes_outpost_credentials(monkeypatch):
         if query is reporting.queries.credential_failure:
             return [
                 {
-                    "SessionResult.slave_or_credential": "/prefix/u1",
+                    "SessionResult.credential_or_slave": "/prefix/u1",
                     "SessionResult.session_type": "ssh",
                     "Count": 1,
                 }
@@ -618,11 +618,11 @@ def test_successful_shows_zero_percent_when_no_success_7d(monkeypatch):
 
     def fake_search_results(search, query):
         if query is reporting.queries.credential_success:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
         if query is reporting.queries.credential_failure:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         if query is reporting.queries.credential_failure_7d:
-            return [{"SessionResult.slave_or_credential": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+            return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         return []
 
     monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
@@ -662,7 +662,7 @@ def test_successful_handles_prefixed_and_mixed_case_credential_paths(monkeypatch
         if query is reporting.queries.credential_success:
             return [
                 {
-                    "SessionResult.slave_or_credential": "Credential/U1",
+                    "SessionResult.credential_or_slave": "Credential/U1",
                     "SessionResult.session_type": "ssh",
                     "Count": 2,
                 }
@@ -678,7 +678,7 @@ def test_successful_handles_prefixed_and_mixed_case_credential_paths(monkeypatch
         if query is reporting.queries.credential_failure:
             return [
                 {
-                    "SessionResult.slave_or_credential": "Credential/U1",
+                    "SessionResult.credential_or_slave": "Credential/U1",
                     "SessionResult.session_type": "ssh",
                     "Count": 4,
                 }
@@ -1069,8 +1069,8 @@ def test_successful_cli_parses_new_headers(monkeypatch):
             return json.dumps(cred)
         if reporting.queries.credential_success in cmd:
             return (
-                "SessionResult.slave_or_credential,SessionResult.session_type,Count\n"
-                "credential/u1,ssh,2\n"
+                "SessionResult.credential_or_slave,uuid,SessionResult.session_type,SessionResult.outpost,Count\n"
+                "credential/u1,credential/u1,ssh,op1,2\n"
             )
         if reporting.queries.deviceinfo_success in cmd:
             return (
@@ -1079,8 +1079,8 @@ def test_successful_cli_parses_new_headers(monkeypatch):
             )
         if reporting.queries.credential_failure in cmd:
             return (
-                "SessionResult.slave_or_credential,SessionResult.session_type,Count\n"
-                "credential/u1,ssh,4\n"
+                "SessionResult.credential_or_slave,uuid,SessionResult.session_type,SessionResult.outpost,Count\n"
+                "credential/u1,credential/u1,ssh,op1,4\n"
             )
         return ""
 


### PR DESCRIPTION
## Summary
- ensure credential reports use `credential or slave` and capture outpost IDs
- record outpost ID alongside URL in credential success report
- parse new `SessionResult.credential_or_slave` field to correctly mark credentials active

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd00b8ba08326a005f94bb8e1c301