### PR TITLE
Handle dict-wrapped results in session_get

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -148,6 +148,12 @@ def session_get(results):
 
     sessions = {}
 
+    # Some API wrappers return a dictionary with a top-level "results" list.
+    # Coerce this structure into the expected list format before validation.
+    if isinstance(results, dict) and "results" in results:
+        logger.debug("session_get coercing dictionary input via 'results' key")
+        results = results["results"]
+
     if not isinstance(results, list):
         logger.warning(
             "session_get expected list of results, got %s", type(results).__name__

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -66,3 +66,24 @@ def test_session_get_normalizes_uuid_case():
         }
     ]
     assert tools.session_get(results) == {"abcdef": ["ssh", 1]}
+
+
+def test_session_get_dict_wrapper():
+    payload = {
+        "results": [
+            {
+                "uuid": "Credential/u1",
+                "SessionResult.session_type": "ssh",
+                "Count": "1",
+            },
+            {
+                "uuid": "Credential/u2",
+                "SessionResult.session_type": "snmp",
+                "Count": "3",
+            },
+        ]
+    }
+    assert tools.session_get(payload) == {
+        "u1": ["ssh", 1],
+        "u2": ["snmp", 3],
+    }


### PR DESCRIPTION
## Summary
- allow `session_get` to accept dict inputs with a `results` key
- log when coercing dictionary results
- test dict wrapper handling

## Testing
- `python3 -m pytest tests/test_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd2f3cfdc83268af09936422fea15