### PR TITLE
Handle dict results in session_get

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -148,6 +148,12 @@ def session_get(results):
 
     sessions = {}
 
+    # Some API endpoints return a dictionary with a top-level "results" key
+    # instead of a plain list.  Normalise this here so callers can supply the
+    # raw API payload without having to unwrap it first.
+    if isinstance(results, dict):
+        results = results.get("results", [])
+
     if not isinstance(results, list):
         logger.warning(
             "session_get expected list of results, got %s", type(results).__name__


### PR DESCRIPTION
## Summary
- support dict payloads with `results` key in `tools.session_get`
- test `reporting.successful` with dict results to ensure active credential counts

## Testing
- `python -m pytest tests/test_reporting.py::test_successful_handles_dict_results -q`
- `python -m pytest tests/test_reporting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd2f618d88326ba16fe4b7f2605e4