### PR TITLE
Log payload when session_get receives unsupported types

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -152,6 +152,7 @@ def session_get(results):
         logger.warning(
             "session_get expected list of results, got %s", type(results).__name__
         )
+        logger.debug("session_get received payload: %r", results)
         return sessions
 
     for result in results:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import ipaddress
+import logging
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import core.tools as tools
@@ -66,3 +67,11 @@ def test_session_get_normalizes_uuid_case():
         }
     ]
     assert tools.session_get(results) == {"abcdef": ["ssh", 1]}
+
+
+def test_session_get_logs_warning_for_invalid_input(caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = tools.session_get("oops")
+    assert result == {}
+    assert "session_get expected list of results, got str" in caplog.text
+    assert "session_get received payload: 'oops'" in caplog.text


### PR DESCRIPTION
## Summary
- log raw payload at debug level when `session_get` receives non-list input
- test warning and payload logging for invalid `session_get` input

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd2f88cc88326b3f5561b55c60ee3