### PR TITLE
Handle explicit zero counts as active

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -200,22 +200,22 @@ def successful(creds, search, args):
         percent7 = 0.0
 
         # Look up success/failure information for this credential
-        sessions = suxCreds.get(uuid, [None, 0])
+        sessions = suxCreds.get(uuid, [None, None])
         logger.debug("UUID %s -> sessions=%s", uuid, sessions)
 
-        devinfos = suxDev.get(uuid, [None, 0])
+        devinfos = suxDev.get(uuid, [None, None])
         logger.debug("UUID %s -> devinfos=%s", uuid, devinfos)
 
-        failure = failCreds.get(uuid, [None, 0])
+        failure = failCreds.get(uuid, [None, None])
         logger.debug("UUID %s -> failure=%s", uuid, failure)
 
-        sessions7 = suxCreds7.get(uuid, [None, 0])
+        sessions7 = suxCreds7.get(uuid, [None, None])
         logger.debug("UUID %s -> sessions7=%s", uuid, sessions7)
 
-        devinfos7 = suxDev7.get(uuid, [None, 0])
+        devinfos7 = suxDev7.get(uuid, [None, None])
         logger.debug("UUID %s -> devinfos7=%s", uuid, devinfos7)
 
-        failure7 = failCreds7.get(uuid, [None, 0])
+        failure7 = failCreds7.get(uuid, [None, None])
         logger.debug("UUID %s -> failure7=%s", uuid, failure7)
 
         # Determine if this credential was seen in any query results, even if
@@ -229,6 +229,17 @@ def successful(creds, search, args):
                 suxCreds7,
                 suxDev7,
                 failCreds7,
+            ]
+        )
+        active = active or any(
+            count is not None
+            for _, count in [
+                sessions,
+                devinfos,
+                failure,
+                sessions7,
+                devinfos7,
+                failure7,
             ]
         )
         logger.debug("UUID %s -> active=%s", uuid, active)
@@ -268,10 +279,10 @@ def successful(creds, search, args):
         excluded_scans = builder.get_scans(excludes_results, list_of_ranges)
         logger.debug("Excluded Scans List %s", excluded_scans)
 
-        fails_all = int(failure[1])
+        fails_all = int(failure[1] or 0)
         if fails_all:
             logger.debug("Failures:%s", fails_all)
-        fails7 = int(failure7[1])
+        fails7 = int(failure7[1] or 0)
 
         # Mark credential as active when any failure data exists so the
         # reporting row is emitted with numeric zeros instead of being

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -537,6 +537,72 @@ def test_successful_reports_zero_counts_for_inactive_credential(monkeypatch, out
     assert row[headers.index("Failures")] == 0
 
 
+@pytest.mark.parametrize("output_csv", [False, True])
+def test_successful_marks_explicit_zero_count_active(monkeypatch, output_csv):
+    cred = {
+        "uuid": "u1",
+        "label": "c",
+        "index": 1,
+        "enabled": True,
+        "username": "user",
+        "usage": "",
+        "iprange": None,
+        "exclusions": None,
+        "types": "ssh",
+    }
+
+    call = {"n": 0}
+
+    def fake_get_json(*a, **k):
+        call["n"] += 1
+        if call["n"] == 1:
+            return [cred]
+        return []
+
+    def fake_search_results(search, query):
+        if query is reporting.queries.credential_success:
+            return [
+                {
+                    "SessionResult.slave_or_credential": "u1",
+                    "SessionResult.session_type": "ssh",
+                    "Count": 0,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(reporting.api, "get_json", fake_get_json)
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.api, "get_outpost_credential_map", lambda *a, **k: {})
+    monkeypatch.setattr(reporting.builder, "get_credentials", lambda entry: entry)
+    monkeypatch.setattr(reporting.builder, "get_scans", lambda *a, **k: [])
+    monkeypatch.setattr(reporting.tools, "completage", lambda *a, **k: 0)
+
+    captured = {}
+
+    def fake_report(data, headers, args, name=""):
+        captured["row"] = data[0]
+        captured["headers"] = headers
+
+    monkeypatch.setattr(reporting, "output", types.SimpleNamespace(report=fake_report))
+
+    args = types.SimpleNamespace(
+        output_csv=output_csv,
+        output_file=None,
+        token=None,
+        target="http://x",
+        include_endpoints=None,
+        endpoint_prefix=None,
+    )
+
+    reporting.successful(DummyCreds(), DummySearch(), args)
+
+    row = captured["row"]
+    headers = captured["headers"]
+    assert row[headers.index("Successes")] == 0
+    assert row[headers.index("Failures")] == 0
+    assert row[headers.index("State")] == "Enabled"
+
+
 def test_successful_includes_outpost_credentials(monkeypatch):
     out_cred = {
         "uuid": "u1",


### PR DESCRIPTION
## Summary
- mark credentials active when any success/failure count exists, even zero
- add regression tests for explicit zero-count credentials

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd2fcc7d48326a86920127dbfa292