### PR TITLE
Handle table-style inputs in session_get

### DIFF
--- a/core/tools.py
+++ b/core/tools.py
@@ -152,6 +152,13 @@ def session_get(results):
     if isinstance(results, dict):
         results = results.get("results", [])
 
+    # Some API endpoints return tabular data as a list of lists where the
+    # first row contains headers.  Normalize this format into a list of
+    # dictionaries before processing so the function can operate on either
+    # representation transparently.
+    if isinstance(results, list) and results and isinstance(results[0], list):
+        results = list_table_to_json(results)
+
     if not isinstance(results, list):
         logger.warning(
             "session_get expected list of results, got %s", type(results).__name__

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -87,3 +87,38 @@ def test_session_get_dict_wrapper():
         "u1": ["ssh", 1],
         "u2": ["snmp", 3],
     }
+
+
+def test_session_get_parses_dict_results():
+    results = [
+        {
+            "SessionResult.credential_or_slave": "Credential/u1",
+            "SessionResult.session_type": "ssh",
+            "Count": "2",
+        },
+        {
+            "SessionResult.credential_or_slave": "Credential/u2",
+            "SessionResult.session_type": "snmp",
+            "Count": 5,
+        },
+    ]
+    assert tools.session_get(results) == {
+        "u1": ["ssh", 2],
+        "u2": ["snmp", 5],
+    }
+
+
+def test_session_get_parses_table_results():
+    rows = [
+        [
+            "SessionResult.credential_or_slave",
+            "SessionResult.session_type",
+            "Count",
+        ],
+        ["Credential/u1", "ssh", "2"],
+        ["Credential/u2", "snmp", 5],
+    ]
+    assert tools.session_get(rows) == {
+        "u1": ["ssh", 2],
+        "u2": ["snmp", 5],
+    }


### PR DESCRIPTION
## Summary
- Normalize list-of-lists responses in `session_get` using `list_table_to_json`
- Add tests for dictionary and table-style `session_get` inputs

## Testing
- `python3 -m pytest tests/test_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd8c34bf083269008a95480682d81