### PR TITLE
Enable paginated search results and expand credential reporting

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -52,25 +52,25 @@ def successful(creds, search, args):
     with ThreadPoolExecutor() as executor:
         futures = {
             "credsux_results": executor.submit(
-                api.search_results, search, queries.credential_success
+                api.search_results, search, queries.credential_success, limit=0
             ),
             "devinfosux": executor.submit(
-                api.search_results, search, queries.deviceinfo_success
+                api.search_results, search, queries.deviceinfo_success, limit=0
             ),
             "credfail_results": executor.submit(
-                api.search_results, search, queries.credential_failure
+                api.search_results, search, queries.credential_failure, limit=0
             ),
             "credsux7_results": executor.submit(
-                api.search_results, search, queries.credential_success_7d
+                api.search_results, search, queries.credential_success_7d, limit=0
             ),
             "devinfosux7": executor.submit(
-                api.search_results, search, queries.deviceinfo_success_7d
+                api.search_results, search, queries.deviceinfo_success_7d, limit=0
             ),
             "credfail7_results": executor.submit(
-                api.search_results, search, queries.credential_failure_7d
+                api.search_results, search, queries.credential_failure_7d, limit=0
             ),
             "outpost_cred_results": executor.submit(
-                api.search_results, search, queries.outpost_credentials
+                api.search_results, search, queries.outpost_credentials, limit=0
             ),
         }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,24 @@ def test_search_results_error_non_json():
     assert search_results(search, {"query": "q"}) == {"error": "Internal Server Error"}
 
 
+def test_search_results_paginates(monkeypatch):
+    """search_results should accumulate more than 500 rows when limit=0."""
+
+    total = 800
+
+    class PagingSearch:
+        def search(self, query, format="object", limit=500, offset=0):
+            data = [{"row": i} for i in range(offset, min(offset + limit, total))]
+            return DummyResponse(200, json.dumps(data))
+
+    # Simplify downstream processing
+    monkeypatch.setattr(api_mod.tools, "list_table_to_json", lambda x: x)
+
+    search = PagingSearch()
+    results = search_results(search, {"query": "q"}, limit=0)
+    assert len(results) == total
+
+
 def test_show_runs_handles_bad_response(capsys):
     resp = DummyResponse(401, 'not-json', reason="Unauthorized")
     disco = DummyDisco(resp)


### PR DESCRIPTION
## Summary
- allow `search_results` to paginate with a configurable limit (0 for no limit)
- update credential success reporting to fetch all credential data
- test pagination and full credential report generation

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd8cc92b4832698e6d1700458565e