### PR TITLE
Warn when Search API returns server errors

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1165,6 +1165,19 @@ def search_results(api_endpoint, query, limit=500):
                         status_code,
                         getattr(results, "reason", ""),
                     )
+                    if status_code >= 500:
+                        reason = getattr(results, "reason", "") or "server error"
+                        # Highlight server-side failures so users know results may
+                        # not reflect the full dataset.
+                        if status_code == 504:
+                            msg_reason = "timed out"
+                        else:
+                            msg_reason = reason.lower()
+                        warning_msg = (
+                            f"*** WARNING: Search API {msg_reason} ({status_code}). "
+                            "Results may be incomplete. ***"
+                        )
+                        print(warning_msg)
                     try:
                         data = json.loads(results.text)
                     except Exception:
@@ -1185,6 +1198,9 @@ def search_results(api_endpoint, query, limit=500):
                     print(msg)
                     logger.error(msg)
                     return []
+                if isinstance(data, dict) and isinstance(data.get("results"), list):
+                    data = dict(data)
+                    data["results"] = tools.list_table_to_json(data["results"])
             else:
                 data = results
             if logger.isEnabledFor(logging.DEBUG):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,6 +88,16 @@ def test_search_results_error_non_json():
     search = DummySearch(resp)
     assert search_results(search, {"query": "q"}) == {"error": "Internal Server Error"}
 
+
+def test_search_results_warns_on_server_error(capfd):
+    resp = DummyResponse(504, 'Gateway Timeout', reason='Gateway Timeout')
+    search = DummySearch(resp)
+    search_results(search, {"query": "q"})
+    out = capfd.readouterr().out
+    assert 'WARNING' in out
+    assert '504' in out
+    assert 'Results may be incomplete' in out
+
 def test_search_results_paginates(monkeypatch):
     """search_results should accumulate more than 500 rows when limit=0."""
 


### PR DESCRIPTION
## Summary
- print a prominent warning when the Search API responds with 5xx errors (e.g. 504)
- normalize tabular `results` payloads to list-of-dicts when returned by the API
- test that a 504 response emits the warning message

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf478a00c8326a06566d066d6e3c3