### PR TITLE
Add persistent caching for API queries and offline reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ python3 dismal.py --config config.yaml --sysadmin audit
 CLI flags override YAML values, so `--access_method cli` on the command line
 would replace any `access_method` defined in the file.
 
+### Caching
+
+API query results can be cached to disk so subsequent runs or offline
+reporting do not require live API calls.  Use `--cache-dir <path>` to specify
+where JSON cache files are stored.  When the `--queries` option is used, the
+retrieved results are written to this cache and later reused by reports such as
+`--excavate credential_success`.  Supply `--no-cache` to bypass the cache and
+force fresh API calls.  The `cache_dir` and `no_cache` options may also be set
+in the YAML configuration file.
+
 ### Endpoint filtering
 
 Device-centric reports can now be limited to a subset of endpoints.  Supplying

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -13,3 +13,5 @@ appliances:
 access_method: <api_or_cli>
 noping: false
 debug: false
+cache_dir: <cache_directory>
+no_cache: false

--- a/core/cache.py
+++ b/core/cache.py
@@ -1,0 +1,71 @@
+import json
+import os
+import hashlib
+
+_CACHE_DIR = None
+_ENABLED = True
+
+
+def configure(cache_dir=None, enabled=True):
+    """Configure the cache directory and enabled state."""
+    global _CACHE_DIR, _ENABLED
+    _CACHE_DIR = cache_dir
+    _ENABLED = enabled
+
+
+def is_enabled():
+    """Return True if caching is enabled and a directory is set."""
+    return _ENABLED and _CACHE_DIR is not None
+
+
+def canonical_query(query):
+    """Normalise query input into a consistent structure."""
+    if isinstance(query, str):
+        query = {"query": query}
+    if isinstance(query, dict) and isinstance(query.get("query"), str):
+        q = dict(query)
+        q["query"] = q["query"].replace("\n", " ").replace("\r", " ")
+        return q
+    return query
+
+
+def _key(name, query, limit):
+    key_data = {"name": name, "query": query, "limit": limit}
+    key_json = json.dumps(key_data, sort_keys=True, default=str)
+    digest = hashlib.sha1(key_json.encode("utf-8")).hexdigest()
+    if name:
+        return f"{name}_{digest}.json"
+    return f"{digest}.json"
+
+
+def _path(name, query, limit):
+    if _CACHE_DIR is None:
+        return None
+    filename = _key(name, query, limit)
+    return os.path.join(_CACHE_DIR, filename)
+
+
+def load(name, query, limit):
+    """Load cached JSON for a query if available."""
+    if not is_enabled():
+        return None
+    path = _path(name, canonical_query(query), limit)
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def save(name, query, limit, data):
+    """Save JSON data for a query to the cache."""
+    if not is_enabled():
+        return
+    path = _path(name, canonical_query(query), limit)
+    if not path:
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)

--- a/core/output.py
+++ b/core/output.py
@@ -238,8 +238,8 @@ def cmd2csv(header,result,seperator,filename,appliance):
                 txt_dump(result,filename)
     csv_file(data, header, filename)
 
-def query2csv(search, query, filename, appliance):
-    response = api.search_results(search, query)
+def query2csv(search, query, filename, appliance, query_name=None):
+    response = api.search_results(search, query, limit=0, cache_name=query_name)
     if type(response) == list and len(response) > 0:
         header, data, _ = tools.json2csv(response)
         header.insert(0, "Discovery Instance")
@@ -271,7 +271,7 @@ def define_txt(args,result,path,filename):
         else:
             txt_dump(result,path)
 
-def define_csv(args, head_ep, data, path, file, target, type, tku=None):
+def define_csv(args, head_ep, data, path, file, target, type, tku=None, query_name=None):
     """Manage CSV-based output options.
 
     When ``tku`` is provided, it is inserted as the second column after the
@@ -306,7 +306,7 @@ def define_csv(args, head_ep, data, path, file, target, type, tku=None):
                 save2csv(data, path, target, tku)
     elif type == "query":
         if args.output_file:
-            query2csv(head_ep, data, file, target)
+            query2csv(head_ep, data, file, target, query_name)
         elif args.output_csv:
             msg ="DisMAL: Output cannot be export to CLI."
             logger.warning(msg)
@@ -319,7 +319,7 @@ def define_csv(args, head_ep, data, path, file, target, type, tku=None):
                 logger.warning(msg)
                 print(msg)
             else:
-                query2csv(head_ep, data, path, target)
+                query2csv(head_ep, data, path, target, query_name)
     elif type == "csv_file":
         if args.output_file:
             csv_file(data, head_ep, file)

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -52,25 +52,60 @@ def successful(creds, search, args):
     with ThreadPoolExecutor() as executor:
         futures = {
             "credsux_results": executor.submit(
-                api.search_results, search, queries.credential_success, limit=0
+                api.search_results,
+                search,
+                queries.credential_success,
+                0,
+                True,
+                "credential_success",
             ),
             "devinfosux": executor.submit(
-                api.search_results, search, queries.deviceinfo_success, limit=0
+                api.search_results,
+                search,
+                queries.deviceinfo_success,
+                0,
+                True,
+                "deviceinfo_success",
             ),
             "credfail_results": executor.submit(
-                api.search_results, search, queries.credential_failure, limit=0
+                api.search_results,
+                search,
+                queries.credential_failure,
+                0,
+                True,
+                "credential_failure",
             ),
             "credsux7_results": executor.submit(
-                api.search_results, search, queries.credential_success_7d, limit=0
+                api.search_results,
+                search,
+                queries.credential_success_7d,
+                0,
+                True,
+                "credential_success_7d",
             ),
             "devinfosux7": executor.submit(
-                api.search_results, search, queries.deviceinfo_success_7d, limit=0
+                api.search_results,
+                search,
+                queries.deviceinfo_success_7d,
+                0,
+                True,
+                "deviceinfo_success_7d",
             ),
             "credfail7_results": executor.submit(
-                api.search_results, search, queries.credential_failure_7d, limit=0
+                api.search_results,
+                search,
+                queries.credential_failure_7d,
+                0,
+                True,
+                "credential_failure_7d",
             ),
             "outpost_cred_results": executor.submit(
-                api.search_results, search, queries.outpost_credentials, limit=0
+                api.search_results,
+                search,
+                queries.outpost_credentials,
+                0,
+                True,
+                "outpost_credentials",
             ),
         }
 
@@ -133,36 +168,21 @@ def successful(creds, search, args):
                         info["url"] = url
 
     # Include Scan Ranges and Excludes
-    scan_resp = search.search(queries.scanrange, format="object", limit=500)
-    scan_ranges = api.get_json(scan_resp)
-    excludes_resp = search.search(queries.excludes, format="object", limit=500)
-    excludes = api.get_json(excludes_resp)
-
-    if not scan_ranges or not isinstance(scan_ranges, list):
-        logger.warning("Failed to retrieve scan ranges; column will be blank")
-        scan_ranges_results = []
-    elif len(scan_ranges) == 0:
-        logger.warning("No scan ranges returned; column will be blank")
-        scan_ranges_results = []
+    scan_ranges = api.search_results(
+        search, queries.scanrange, limit=0, cache_name="scanrange"
+    )
+    if isinstance(scan_ranges, dict):
+        scan_ranges_results = scan_ranges.get("results", [])
     else:
-        first = scan_ranges[0]
-        if isinstance(first, dict) and "results" in first:
-            scan_ranges_results = first.get("results", [])
-        else:
-            scan_ranges_results = scan_ranges
+        scan_ranges_results = scan_ranges or []
 
-    if not excludes or not isinstance(excludes, list):
-        logger.warning("Failed to retrieve excludes; column will be blank")
-        excludes_results = []
-    elif len(excludes) == 0:
-        logger.warning("No exclude data returned; column will be blank")
-        excludes_results = []
+    excludes = api.search_results(
+        search, queries.excludes, limit=0, cache_name="excludes"
+    )
+    if isinstance(excludes, dict):
+        excludes_results = excludes.get("results", [])
     else:
-        first = excludes[0]
-        if isinstance(first, dict) and "results" in first:
-            excludes_results = first.get("results", [])
-        else:
-            excludes_results = excludes
+        excludes_results = excludes or []
 
     timer_count = 0
     for cred in vaultcreds:

--- a/dismal.py
+++ b/dismal.py
@@ -15,7 +15,7 @@ import sys
 import yaml
 from argparse import RawTextHelpFormatter
 
-from core import access, api, builder, cli, curl, output, reporting, tools
+from core import access, api, builder, cli, curl, output, reporting, tools, cache
 
 logfile = 'dismal_%s.log'%( str(datetime.date.today() ))
 
@@ -65,6 +65,24 @@ outputs.add_argument('-f', '--file',    dest='output_file', type=str, required=F
 outputs.add_argument('-s', '--path',    dest='output_path', type=str, required=False, help='Path to save bulk files (default=pwd).\n\n',metavar='<path>')
 outputs.add_argument('--null',          dest='output_null',  action='store_true', required=False, help='Run report functions but do not output data (used for debugging).\n\n')
 outputs.add_argument('--stdout',       dest='output_cli', action='store_true', required=False, help='Print results to CLI instead of writing to output directory.\n\n')
+
+# Cache Options
+cache_opts = parser.add_argument_group("Cache Options")
+cache_opts.add_argument(
+    '--cache-dir',
+    dest='cache_dir',
+    type=str,
+    required=False,
+    help='Directory to store cached API query results.\n\n',
+    metavar='<path>',
+)
+cache_opts.add_argument(
+    '--no-cache',
+    dest='no_cache',
+    action='store_true',
+    required=False,
+    help='Force fresh API calls without reading or writing cache.\n\n',
+)
 
 # Hidden Options
 parser.add_argument('-k', '--keep-awake',   dest='wakey', action='store_true', required=False, help=argparse.SUPPRESS)
@@ -218,10 +236,13 @@ parser.set_defaults(
     # Support both ``debug`` and legacy ``debugging`` keys in the YAML config
     # file so existing configurations continue to work.
     debugging=config.get('debug', config.get('debugging', False)),
+    cache_dir=config.get('cache_dir'),
+    no_cache=config.get('no_cache', False),
 )
 
 global args
 args = parser.parse_args(remaining_argv)
+cache.configure(getattr(args, "cache_dir", None), enabled=not getattr(args, "no_cache", False))
 
 def run_for_args(args):
     start_time = time.time()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -304,7 +304,7 @@ def test_get_outposts_uses_deleted_false():
 def test_run_queries_executes_named_query(monkeypatch, tmp_path):
     recorded = {}
 
-    def fake_define_csv(args, search, query, path, file, target, typ):
+    def fake_define_csv(args, search, query, path, file, target, typ, **kwargs):
         recorded["search"] = search
         recorded["query"] = query
         recorded["path"] = path
@@ -329,7 +329,7 @@ def test_run_queries_executes_named_query(monkeypatch, tmp_path):
 def test_run_queries_executes_report_queries(monkeypatch, tmp_path):
     captured = []
 
-    def fake_define_csv(args, search, query, path, file, target, typ):
+    def fake_define_csv(args, search, query, path, file, target, typ, **kwargs):
         captured.append((query, path, typ))
 
     monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
@@ -351,6 +351,7 @@ def test_run_queries_executes_report_queries(monkeypatch, tmp_path):
         "credential_failure_7d",
         "scanrange",
         "excludes",
+        "outpost_credentials",
     ]
     expected_queries = [getattr(api_mod.queries, n) for n in expected_names]
     assert [q for q, _, _ in captured] == expected_queries

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,62 @@
+import types
+from core import api, cache, queries, reporting
+
+
+def test_run_queries_populates_cache(tmp_path):
+    cache.configure(tmp_path)
+
+    class Search:
+        def search_bulk(self, query, format="object", limit=500, offset=0):
+            return [{"col": "val"}]
+
+    args = types.SimpleNamespace(
+        excavate=["credential_success"],
+        output_cli=False,
+        output_csv=False,
+        output_file=None,
+        output_null=False,
+        target="app",
+    )
+
+    api.run_queries(Search(), args, tmp_path)
+    assert any(p.name.startswith("credential_success_") for p in tmp_path.iterdir())
+
+
+def test_successful_uses_cache(tmp_path, monkeypatch):
+    cache.configure(tmp_path)
+    qnames = [
+        "credential_success",
+        "deviceinfo_success",
+        "credential_failure",
+        "credential_success_7d",
+        "deviceinfo_success_7d",
+        "credential_failure_7d",
+        "outpost_credentials",
+        "scanrange",
+        "excludes",
+    ]
+    for name in qnames:
+        query = getattr(queries, name)
+        cache.save(name, query, 0, [])
+
+    monkeypatch.setattr(reporting.api, "get_json", lambda *a, **k: [])
+
+    class Creds:
+        def get_vault_credentials(self):
+            return []
+
+    class Search:
+        def search_bulk(self, *a, **k):
+            raise AssertionError("API should not be called when cached data is available")
+
+    args = types.SimpleNamespace(
+        target=None,
+        output_cli=False,
+        output_csv=False,
+        output_file=None,
+        output_null=False,
+        reporting_dir=str(tmp_path),
+        excavate=None,
+    )
+
+    reporting.successful(Creds(), Search(), args)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -93,7 +93,7 @@ def test_successful_writes_all_credentials(tmp_path, monkeypatch):
 
     called_limits = []
 
-    def fake_search_results(api_endpoint, query, limit=500):
+    def fake_search_results(api_endpoint, query, limit=500, *args, **kwargs):
         called_limits.append(limit)
         return [{} for _ in range(total)]
 
@@ -343,20 +343,28 @@ def test_successful_runs_without_scan_data(monkeypatch):
 def test_successful_combines_query_results(monkeypatch):
     calls = []
 
-    def fake_search_results(search, query, limit=500):
-        calls.append(query)
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
         if query is reporting.queries.deviceinfo_success:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 3}]
         if query is reporting.queries.credential_failure:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 4}]
         if query is reporting.queries.credential_success_7d:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         if query is reporting.queries.deviceinfo_success_7d:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
         if query is reporting.queries.credential_failure_7d:
+            calls.append(query)
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 1}]
+        if query is reporting.queries.outpost_credentials:
+            calls.append(query)
+            return []
         return []
 
     call = {"n": 0}
@@ -416,7 +424,7 @@ def test_successful_combines_query_results(monkeypatch):
 def test_successful_coerces_string_counts(monkeypatch):
     """Counts provided as strings should be converted to numbers."""
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": "2"}]
         if query is reporting.queries.deviceinfo_success:
@@ -485,7 +493,7 @@ def test_successful_coerces_string_counts(monkeypatch):
 
 
 def test_successful_emits_row_when_deviceinfo_7d_empty(monkeypatch):
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return []
         if query is reporting.queries.deviceinfo_success:
@@ -634,7 +642,7 @@ def test_successful_marks_explicit_zero_count_active(monkeypatch, output_csv):
             return [cred]
         return []
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return [
                 {
@@ -690,7 +698,7 @@ def test_successful_includes_outpost_credentials(monkeypatch):
         "exclusions": None,
     }
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return [
                 {
@@ -757,7 +765,7 @@ def test_successful_shows_zero_percent_when_no_success_7d(monkeypatch):
         "exclusions": None,
     }
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return [{"SessionResult.credential_or_slave": "u1", "SessionResult.session_type": "ssh", "Count": 2}]
         if query is reporting.queries.credential_failure:
@@ -799,7 +807,7 @@ def test_successful_shows_zero_percent_when_no_success_7d(monkeypatch):
 def test_successful_handles_prefixed_and_mixed_case_credential_paths(monkeypatch):
     """Query results may return object-path prefixes and mixed-case UUIDs."""
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_success:
             return [
                 {
@@ -881,7 +889,7 @@ def test_successful_handles_prefixed_and_mixed_case_credential_paths(monkeypatch
 def test_successful_uses_uuid_for_failures(monkeypatch):
     """Failure queries may only include a raw 'uuid' field."""
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.credential_failure:
             return [
                 {
@@ -894,13 +902,16 @@ def test_successful_uses_uuid_for_failures(monkeypatch):
             return [
                 {"uuid": "u1", "SessionResult.session_type": "ssh", "Count": 1}
             ]
-        if query in {
-            reporting.queries.credential_success,
-            reporting.queries.deviceinfo_success,
-            reporting.queries.credential_success_7d,
-            reporting.queries.deviceinfo_success_7d,
-            reporting.queries.outpost_credentials,
-        }:
+        if any(
+            query == q
+            for q in [
+                reporting.queries.credential_success,
+                reporting.queries.deviceinfo_success,
+                reporting.queries.credential_success_7d,
+                reporting.queries.deviceinfo_success_7d,
+                reporting.queries.outpost_credentials,
+            ]
+        ):
             return []
         return []
 
@@ -1008,7 +1019,7 @@ def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
 
     monkeypatch.setattr(reporting.builder, "unique_identities", lambda s, *a, **k: [])
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.last_disco:
             return [
                 {
@@ -1082,7 +1093,7 @@ def test_discovery_analysis_merges_latest_fields(monkeypatch):
 
     monkeypatch.setattr(reporting.builder, "unique_identities", lambda s, *a, **k: [])
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query is reporting.queries.last_disco:
             return [
                 {
@@ -1215,7 +1226,7 @@ def test_successful_handles_dict_results(monkeypatch):
 
     monkeypatch.setattr(reporting.api, "get_json", fake_get_json)
 
-    def fake_search_results(search, query, limit=500):
+    def fake_search_results(search, query, limit=500, *args, **kwargs):
         if query == reporting.queries.credential_success:
             return {
                 "results": [


### PR DESCRIPTION
## Summary
- implement `core.cache` for JSON query caching
- use cached search results in API, reporting, and `--queries` workflow
- add CLI options for cache directory and disabling cache
- document cache usage and add regression tests

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf7e7e4748326a61792a8f7eba80e