### PR TITLE
Handle over-limit search responses

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1264,6 +1264,11 @@ def search_results(api_endpoint, query, limit=500, use_cache=True, cache_name=No
 
             results_all.extend(data)
 
+            # If limit==0 and the server already returned more rows than requested,
+            # treat this as the complete result set and exit.
+            if not limit and offset == 0 and len(data) > page_limit:
+                break
+
             # Stop when we've retrieved the requested number of rows or when
             # the API returns fewer rows than requested for a given page.
             if limit and limit > 0 and len(results_all) >= limit:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,6 +115,28 @@ def test_search_results_paginates(monkeypatch):
     results = search_results(search, {"query": "q"}, limit=0)
     assert len(results) == total
 
+
+def test_search_results_breaks_on_overlimit(monkeypatch):
+    """If API returns more rows than requested, only one request should be made."""
+
+    class OverLimitSearch:
+        def __init__(self):
+            self.calls = []
+
+        def search(self, query, format="object", limit=500, offset=0):
+            self.calls.append((limit, offset))
+            assert offset == 0  # Ensure pagination does not occur
+            data = [{"row": i} for i in range(600)]
+            return DummyResponse(200, json.dumps(data))
+
+    monkeypatch.setattr(api_mod.tools, "list_table_to_json", lambda x: x)
+
+    search = OverLimitSearch()
+    results = search_results(search, {"query": "q"}, limit=0)
+
+    assert len(results) == 600
+    assert search.calls == [(500, 0)]
+
 def test_search_results_normalizes_nested_results():
     payload = {
         "count": 1,


### PR DESCRIPTION
## Summary
- avoid infinite pagination when server returns more rows than requested
- add regression test for over-limit search results

## Testing
- `python3 -m pytest tests/test_api.py::test_search_results_breaks_on_overlimit -q`
- `python3 -m pytest tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad01da9e5c83269b2c90b53a3181a6