### PR TITLE
feat: make search page size configurable

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -257,8 +257,8 @@ def query(search, args):
 
 def get_outposts(appliance):
     """Return list of Discovery Outposts from the appliance."""
-    logger.debug("Calling appliance.get('/discovery/outposts')")
-    resp = appliance.get("/discovery/outposts")
+    logger.debug("Calling appliance.get('/discovery/outposts?deleted=false')")
+    resp = appliance.get("/discovery/outposts?deleted=false")
     logger.debug(
         "outposts response ok=%s status=%s text=%s",
         getattr(resp, "ok", "N/A"),
@@ -570,7 +570,20 @@ def update_cred(appliance, uuid):
             active = True
     return active
 
-def search_results(api_endpoint,query):
+def search_results(api_endpoint, query, page_size=500):
+    """Return results from a Discovery API search.
+
+    Parameters
+    ----------
+    api_endpoint : object
+        The API endpoint object exposing ``search`` or ``search_bulk``.
+    query : dict or str
+        The query to execute.
+    page_size : int, optional
+        Number of results requested per page from the API.  Increasing the
+        value reduces the number of calls needed but may increase memory and
+        network load.  Defaults to ``500``.
+    """
     try:
         if logger.isEnabledFor(logging.DEBUG):
             try:
@@ -578,9 +591,9 @@ def search_results(api_endpoint,query):
             except Exception:
                 pass
         if hasattr(api_endpoint, "search_bulk"):
-            results = api_endpoint.search_bulk(query, format="object", limit=500)
+            results = api_endpoint.search_bulk(query, format="object", limit=page_size)
         else:
-            results = api_endpoint.search(query, format="object", limit=500)
+            results = api_endpoint.search(query, format="object", limit=page_size)
         # Depending on the version of the `tideway` library the call above may
         # return either a `requests.Response` object or the decoded JSON
         # directly.  Normalise the output so callers always get Python data

--- a/core/builder.py
+++ b/core/builder.py
@@ -570,8 +570,10 @@ def unique_identities(search):
 
     logger.info("Running: Unique Identities report...")
 
-    devices = api.search_results(search,queries.deviceInfo)
-    da_results = api.search_results(search,queries.da_ip_lookup)
+    # Use a larger page size for these potentially large queries to reduce
+    # the number of round trips to the Discovery API.
+    devices = api.search_results(search, queries.deviceInfo, page_size=1000)
+    da_results = api.search_results(search, queries.da_ip_lookup, page_size=1000)
 
     ### list of unique endpoints
     unique_endpoints = []

--- a/cred_success_debug.py
+++ b/cred_success_debug.py
@@ -221,7 +221,7 @@ def get_json(api_endpoint):
                 pass
         return data
 
-def search_results(api_endpoint, query):
+def search_results(api_endpoint, query, page_size=500):
     try:
         if logger.isEnabledFor(logging.DEBUG):
             try:
@@ -229,9 +229,9 @@ def search_results(api_endpoint, query):
             except Exception:
                 pass
         if hasattr(api_endpoint, "search_bulk"):
-            results = api_endpoint.search_bulk(query, format="object", limit=500)
+            results = api_endpoint.search_bulk(query, format="object", limit=page_size)
         else:
-            results = api_endpoint.search(query, format="object", limit=500)
+            results = api_endpoint.search(query, format="object", limit=page_size)
         if hasattr(results, "json"):
             if logger.isEnabledFor(logging.DEBUG):
                 try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,10 @@ class DummyResponse:
 class DummySearch:
     def __init__(self, response):
         self._response = response
+        self.limit = None
+
     def search(self, query, format="object", limit=500):
+        self.limit = limit
         return self._response
 
 class DummyDisco:
@@ -45,6 +48,13 @@ def test_search_results_fallback():
     resp = DummyResponse(200, '[{"ok": true}]')
     search = DummySearch(resp)
     assert search_results(search, {"query": "q"}) == [{"ok": True}]
+
+
+def test_search_results_respects_page_size():
+    resp = DummyResponse(200, '[{"ok": true}]')
+    search = DummySearch(resp)
+    search_results(search, {"query": "q"}, page_size=42)
+    assert search.limit == 42
 
 
 def test_show_runs_handles_bad_response(capsys):


### PR DESCRIPTION
## Summary
- allow callers to tune Discovery API page size via new `page_size` parameter
- use larger page size in `unique_identities` to cut down API requests
- ensure `get_outposts` includes `deleted=false` filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad059b354c8326819511b59cf1f42f