### PR TITLE
Remove unused discovery access lookup in unique_identities

### DIFF
--- a/core/builder.py
+++ b/core/builder.py
@@ -718,10 +718,6 @@ def unique_identities(
     devices = api.search_results(
         search, device_query, cache_name="unique_identities_devices"
     )
-    da_results = api.search_results(
-        search, da_query, cache_name="unique_identities_da"
-    )
-
     if not isinstance(devices, list):
         logger.error("Failed to retrieve unique identity data")
         return []


### PR DESCRIPTION
## Summary
- remove unused discovery-access search from `unique_identities`

## Testing
- `python3 -m pytest tests/test_excavate_identities.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad116d62e88326b7537b7cfbe5ffb9