### PR TITLE
Run device_ids query when using --queries

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1329,7 +1329,8 @@ REPORT_QUERY_MAP = {
         "scanrange",
         "excludes",
         "outpost_credentials",
-    ]
+    ],
+    "device_ids": ["deviceInfo"],
 }
 
 def run_queries(search, args, dir):

--- a/dismal.py
+++ b/dismal.py
@@ -336,7 +336,7 @@ def run_for_args(args):
         system_user, system_passwd = access.login_target(cli_target, args)
 
     identities = None
-    if api_target and (
+    if api_target and not getattr(args, "queries", False) and (
         args.access_method == "all"
         or excavate_default
         or (args.excavate and args.excavate[0] in ("devices", "device_ids"))


### PR DESCRIPTION
## Summary
- map `device_ids` report to its underlying `deviceInfo` query
- skip building device identities when `--queries` is specified
- test that `--excavate device_ids --queries` executes the `deviceInfo` query and bypasses identity building

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6f97ce4c8326b481fb23b908e8d8