### PR TITLE
Add DeviceInfo network query

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -96,6 +96,21 @@ deviceInfo = {"query":
                             process with unique()
                         """
                 }
+
+deviceInfo_network = {
+                        "query":
+                            """
+                                search DeviceInfo
+                                ORDER BY hostname
+                                show
+                                hostname as 'DeviceInfo.hostname',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.__all_ip_addrs as 'InferredElement.__all_ip_addrs',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.ip_addr as 'NetworkInterface.ip_addr',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.fqdns as 'NetworkInterface.fqdns',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DiscoveredIPAddressList.#List:List:Member:DiscoveredIPAddress.ip_addr as 'DiscoveredIPAddress.ip_addr'
+                                process with unique()
+                            """
+                }
 da_ip_lookup = {
                     "query":
                             """


### PR DESCRIPTION
## Summary
- add `deviceInfo_network` query to expose network-related DeviceInfo attributes

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad78cf50588326b67a24e4eb8e2564