### PR TITLE
Use base deviceInfo query in device_ids report

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1391,7 +1391,9 @@ REPORT_QUERY_MAP = {
         "excludes",
         "outpost_credentials",
     ],
-    "device_ids": ["deviceInfo"],
+    # The device_ids report now composes multiple queries to avoid timeouts
+    # from the former monolithic deviceInfo request.
+    "device_ids": ["deviceInfo_base", "deviceInfo_network", "deviceInfo_access"],
 }
 
 def run_queries(search, args, dir):

--- a/core/queries.py
+++ b/core/queries.py
@@ -67,6 +67,7 @@ deviceInfo_base = {"query":
                             os_type as 'DeviceInfo.os_type',
                             sysname as 'DeviceInfo.sysname',
                             device_type as 'DeviceInfo.device_type',
+                            #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endpoint as 'DiscoveryAccess.endpoint',
                             fqdn as 'DeviceInfo.fqdn',
                             kind as 'DeviceInfo.kind',
                             method_success as 'DeviceInfo.method_success',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -420,12 +420,10 @@ def test_run_queries_executes_report_queries(monkeypatch, tmp_path):
 
 
 def test_run_queries_executes_device_ids_query(monkeypatch, tmp_path):
-    captured = {}
+    captured = []
 
     def fake_define_csv(args, search, query, path, file, target, typ, **kwargs):
-        captured["query"] = query
-        captured["path"] = path
-        captured["type"] = typ
+        captured.append((query, path, typ))
 
     monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
 
@@ -437,10 +435,18 @@ def test_run_queries_executes_device_ids_query(monkeypatch, tmp_path):
 
     api_mod.run_queries(search, args, outdir)
 
-    assert captured["query"] == api_mod.queries.deviceInfo
-    expected = os.path.join(outdir, "qry_deviceInfo.csv")
-    assert captured["path"] == expected
-    assert captured["type"] == "query"
+    expected = [
+        api_mod.queries.deviceInfo_base,
+        api_mod.queries.deviceInfo_network,
+        api_mod.queries.deviceInfo_access,
+    ]
+    assert [q for q, _, _ in captured] == expected
+    assert [t for _, _, t in captured] == ["query", "query", "query"]
+    assert [p for _, p, _ in captured] == [
+        os.path.join(outdir, "qry_deviceInfo_base.csv"),
+        os.path.join(outdir, "qry_deviceInfo_network.csv"),
+        os.path.join(outdir, "qry_deviceInfo_access.csv"),
+    ]
 
 
 def test_map_outpost_credentials_strips_scheme(monkeypatch):

--- a/tests/test_missing_vms.py
+++ b/tests/test_missing_vms.py
@@ -45,18 +45,28 @@ def test_missing_vms_calls_completage(monkeypatch):
 def test_missing_vms_enriches_from_devices(monkeypatch):
     missing = [{"VirtualMachine.guest_full_name": "h1"}]
 
-    device_info = [{
-        "DiscoveryAccess.endpoint": "1.2.3.4",
-        "DeviceInfo.hostname": "id1",
-        "DiscoveryAccess.starttime": "2024-01-01 10:00:00",
-        "DiscoveryAccess.result": "OK",
-    }]
+    device_base = [
+        {
+            "DiscoveryAccess.endpoint": "1.2.3.4",
+            "DeviceInfo.hostname": "id1",
+        }
+    ]
+    device_access = [
+        {
+            "DiscoveryAccess.endpoint": "1.2.3.4",
+            "DeviceInfo.hostname": "id1",
+            "DiscoveryAccess.starttime": "2024-01-01 10:00:00",
+            "DiscoveryAccess.result": "OK",
+        }
+    ]
 
     def fake_search_results(search, query):
         if query == api_mod.queries.missing_vms:
             return missing
-        if query == api_mod.queries.deviceInfo:
-            return device_info
+        if query == api_mod.queries.deviceInfo_base:
+            return device_base
+        if query == api_mod.queries.deviceInfo_access:
+            return device_access
         return []
 
     captured = {}


### PR DESCRIPTION
## Summary
- build unique device ID report by orchestrating `deviceInfo_base`, `deviceInfo_network`, and `deviceInfo_access`
- include endpoint field in `deviceInfo_base`
- update device_ids run-queries mapping and tests

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7839eab88326943743c8f828e811