### PR TITLE
Use granular queries for device identity reports

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1393,7 +1393,7 @@ REPORT_QUERY_MAP = {
     ],
     # The device_ids report now composes multiple queries to avoid timeouts
     # from the former monolithic deviceInfo request.
-    "device_ids": ["deviceInfo_base", "deviceInfo_network", "deviceInfo_access"],
+    "device_ids": ["deviceInfo_base", "deviceInfo_access", "deviceInfo_network"],
 }
 
 def run_queries(search, args, dir):

--- a/core/builder.py
+++ b/core/builder.py
@@ -672,6 +672,14 @@ def unique_identities(
 ):
     """Return a list of unique device identities.
 
+    This routine now queries the appliance using the granular
+    ``deviceInfo_*`` lookups instead of the former monolithic
+    ``deviceInfo`` request.  ``deviceInfo_access`` seeds the list of
+    devices/endpoints, ``deviceInfo_base`` contributes identity details,
+    and ``deviceInfo_network`` merges any network metadata.  The combined
+    results replicate the original behaviour while reducing the payload
+    size and allowing the network query to be skipped when not required.
+
     Parameters
     ----------
     search: object

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -437,15 +437,15 @@ def test_run_queries_executes_device_ids_query(monkeypatch, tmp_path):
 
     expected = [
         api_mod.queries.deviceInfo_base,
-        api_mod.queries.deviceInfo_network,
         api_mod.queries.deviceInfo_access,
+        api_mod.queries.deviceInfo_network,
     ]
     assert [q for q, _, _ in captured] == expected
     assert [t for _, _, t in captured] == ["query", "query", "query"]
     assert [p for _, p, _ in captured] == [
         os.path.join(outdir, "qry_deviceInfo_base.csv"),
-        os.path.join(outdir, "qry_deviceInfo_network.csv"),
         os.path.join(outdir, "qry_deviceInfo_access.csv"),
+        os.path.join(outdir, "qry_deviceInfo_network.csv"),
     ]
 
 


### PR DESCRIPTION
## Summary
- map `device_ids` report to `deviceInfo_base`, `deviceInfo_access`, and `deviceInfo_network`
- document granular query workflow in `builder.unique_identities`
- update tests for new query order

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8533c3fc83268b5f11da2713ec1a