### PR TITLE
Remove coverage from device_ids report

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,6 @@ python3 dismal.py --access_method api -i <appliance_host> -u <username> -p <pass
 
 Only the two specified endpoints are queried and reported on.
 
-The resulting device-IDs report includes a **Guide %** column indicating
-the proportion of unique IP addresses seen for each originating endpoint
-compared to the total endpoints examined.
-
 When only a rough sample is required, ``--max-identities <N>`` can be used
 to stop processing after ``N`` originating endpoints have been collected.
 This acts as a hard limit on the unique identities gathered and can
@@ -161,7 +157,7 @@ The toolkit now offers a broad range of reports. Selected examples include:
 
 - **active_scans** – list active Discovery Runs; add `--queries` to run via search query.
 - **credential_success** – report on credential success with totals and success percentages.
-- **device_ids** – list unique device identities with a Guide % for each originating endpoint.
+- **device_ids** – list unique device identities for each originating endpoint.
 - **devices** – summarize unique device profiles with last access and credential details.
 - **discovery_analysis** – export latest access details for each endpoint and compare consecutive runs to highlight state changes.
 - **discovery_run_analysis** – summarises DiscoveryRun details including ranges, endpoint totals, and scan kinds.

--- a/core/builder.py
+++ b/core/builder.py
@@ -844,21 +844,17 @@ def unique_identities(
 
     print(os.linesep)
 
-    total_endpoints = len(endpoint_map)
-
     unique_identities = []
     for endpoint, data in endpoint_map.items():
         ip_list = tools.sortlist(list(data["ips"]), "None") if data["ips"] else []
         name_list = (
             tools.sortlist(list(data["names"]), "None") if data["names"] else []
         )
-        pct = (len(data["ips"]) / total_endpoints * 100) if total_endpoints else 0
         unique_identities.append(
             {
                 "originating_endpoint": endpoint,
                 "list_of_ips": ip_list,
                 "list_of_names": name_list,
-                "coverage_pct": pct,
             }
         )
 

--- a/dismal.py
+++ b/dismal.py
@@ -162,7 +162,7 @@ Providing no <report> or using "default" will run all options that do not requir
 "credential_success"        - Report on credential success with total number of accesses, success %% and ranges
 "db_lifecycle"              - Export Database lifecycle report
 "device" <name>             - Report on a specific device node by name (Host, NetworkDevice, Printer, SNMPManagedDevice, StorageDevice, ManagementController)
-"device_ids"                - Export list of unique device identities with coverage percentage per endpoint
+"device_ids"                - Export list of unique device identities
 "devices"                   - Report of unique device profiles - includes last DiscoveryAccess and last _successful_ DiscoveryAccess results with credential details
 "devices_with_cred" <UUID>  - Run devices report for a specific credential
 "discovery_analysis"        - Report of unique DiscoveryAccesses and dropped endpoints with credential details, consistency analysis and end state change
@@ -723,11 +723,10 @@ def run_for_args(args):
                     identity['originating_endpoint'],
                     identity['list_of_ips'],
                     identity['list_of_names'],
-                    identity.get('coverage_pct'),
                 ])
             output.report(
                 data,
-                ["Origating Endpoint", "List of IPs", "List of Names", "Coverage %"],
+                ["Origating Endpoint", "List of IPs", "List of Names"],
                 args,
                 name="device_ids",
             )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -447,13 +447,11 @@ def test_unique_identities_merges_device_data(monkeypatch):
             "originating_endpoint": "10.0.0.1",
             "list_of_ips": ["10.0.0.1", "10.0.0.2"],
             "list_of_names": ["host1"],
-            "coverage_pct": pytest.approx(100.0),
         },
         {
             "originating_endpoint": "10.0.0.2",
             "list_of_ips": ["10.0.0.1", "10.0.0.2"],
             "list_of_names": ["host1", "host2"],
-            "coverage_pct": pytest.approx(100.0),
         },
     ]
 

--- a/tests/test_excavate_identities.py
+++ b/tests/test_excavate_identities.py
@@ -26,7 +26,6 @@ def test_excavate_devices_and_ids_calls_unique_once(monkeypatch):
                 "originating_endpoint": "1.1.1.1",
                 "list_of_ips": ["1.1.1.1"],
                 "list_of_names": ["h1"],
-                "coverage_pct": 100.0,
             }
         ]
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -206,13 +206,12 @@ def test_successful_writes_all_credentials(tmp_path, monkeypatch):
     assert len(lines) == total + 1  # header + data
     assert all(l == 0 for l in called_limits)
 
-def test_device_ids_report_includes_coverage(monkeypatch):
+def test_device_ids_report_outputs_expected_fields(monkeypatch):
     sample = [
         {
             "originating_endpoint": "10.0.0.1",
             "list_of_ips": ["10.0.0.1"],
             "list_of_names": ["h1"],
-            "coverage_pct": 50.0,
         }
     ]
     monkeypatch.setattr(builder, "unique_identities", lambda *a, **k: sample)
@@ -241,20 +240,18 @@ def test_device_ids_report_includes_coverage(monkeypatch):
                 identity["originating_endpoint"],
                 identity["list_of_ips"],
                 identity["list_of_names"],
-                identity["coverage_pct"],
             ]
         )
 
     output.report(
         data,
-        ["Origating Endpoint", "List of IPs", "List of Names", "Coverage %"],
+        ["Origating Endpoint", "List of IPs", "List of Names"],
         args,
         name="device_ids",
     )
 
     assert captured["data"]
-    assert captured["headers"][-1] == "Coverage %"
-    assert captured["data"][0][-1] == 50.0
+    assert captured["headers"] == ["Origating Endpoint", "List of IPs", "List of Names"]
 
 
 def test_unique_identities_returns_empty_when_no_devices(monkeypatch):


### PR DESCRIPTION
## Summary
- drop `coverage_pct` from unique identities builder and device_ids output
- update CLI help, README, and tests for device_ids without coverage

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad906de3ac8326b112b8248a414ade