### PR TITLE
Use unified device identity query

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1391,9 +1391,8 @@ REPORT_QUERY_MAP = {
         "excludes",
         "outpost_credentials",
     ],
-    # The device_ids report now composes multiple queries to avoid timeouts
-    # from the former monolithic deviceInfo request.
-    "device_ids": ["deviceInfo_base", "deviceInfo_access", "deviceInfo_network"],
+    # The device_ids report uses a dedicated query
+    "device_ids": ["device_ids"],
 }
 
 def run_queries(search, args, dir):

--- a/core/queries.py
+++ b/core/queries.py
@@ -186,6 +186,21 @@ da_ip_lookup = {
                                 #::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.ip_addr as 'NetworkInterface.ip_addr'
                             """
                 }
+device_ids = """
+search DiscoveryAccess
+show
+#::InferredElement:.name as 'InferredElement.name',
+#::InferredElement:.hostname as 'InferredElement.hostname',
+#::InferredElement:.local_fqdn as 'InferredElement.local_fqdn',
+#::InferredElement:.sysname as 'InferredElement.sysname',
+endpoint as 'DiscoveryAccess.endpoint',
+#DiscoveryAccess:Endpoint:Endpoint:Endpoint.endpoint as 'Endpoint.endpoint',
+#DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DiscoveredIPAddressList.#List:List:Member:DiscoveredIPAddress.ip_addr as 'DiscoveredIPAddress.ip_addr',
+#::InferredElement:.__all_ip_addrs as 'InferredElement.__all_ip_addrs',
+#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.ip_addr as 'NetworkInterface.ip_addr',
+#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.fqdns as 'NetworkInterface.fqdns'
+process with unique()
+"""
 excludes = {"query": """search in '_System' ExcludeRange
                             show
                             exrange_id as 'ID',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -435,17 +435,11 @@ def test_run_queries_executes_device_ids_query(monkeypatch, tmp_path):
 
     api_mod.run_queries(search, args, outdir)
 
-    expected = [
-        api_mod.queries.deviceInfo_base,
-        api_mod.queries.deviceInfo_access,
-        api_mod.queries.deviceInfo_network,
-    ]
+    expected = [api_mod.queries.device_ids]
     assert [q for q, _, _ in captured] == expected
-    assert [t for _, _, t in captured] == ["query", "query", "query"]
+    assert [t for _, _, t in captured] == ["query"]
     assert [p for _, p, _ in captured] == [
-        os.path.join(outdir, "qry_deviceInfo_base.csv"),
-        os.path.join(outdir, "qry_deviceInfo_access.csv"),
-        os.path.join(outdir, "qry_deviceInfo_network.csv"),
+        os.path.join(outdir, "qry_device_ids.csv"),
     ]
 
 


### PR DESCRIPTION
## Summary
- add dedicated device_ids query that aggregates endpoint and name data
- refactor unique_identities to leverage new query
- update device_ids reports and tests accordingly

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad968f93b483269ebef29d03f25dc5