### PR TITLE
Add devices report mapping and test

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1393,6 +1393,8 @@ REPORT_QUERY_MAP = {
     ],
     # The device_ids report uses a dedicated query
     "device_ids": ["device_ids"],
+    # The devices report uses the deviceInfo query
+    "devices": ["deviceInfo"],
 }
 
 def run_queries(search, args, dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -443,6 +443,29 @@ def test_run_queries_executes_device_ids_query(monkeypatch, tmp_path):
     ]
 
 
+def test_run_queries_executes_devices_report(monkeypatch, tmp_path):
+    captured = []
+
+    def fake_define_csv(args, search, query, path, file, target, typ, **kwargs):
+        captured.append((query, path, typ))
+
+    monkeypatch.setattr(api_mod.output, "define_csv", fake_define_csv)
+
+    args = types.SimpleNamespace(
+        excavate=["devices"], output_file=None, target="appl"
+    )
+    search = object()
+    outdir = str(tmp_path)
+
+    api_mod.run_queries(search, args, outdir)
+
+    assert [q for q, _, _ in captured] == [api_mod.queries.deviceInfo]
+    assert [p for _, p, _ in captured] == [
+        os.path.join(outdir, "qry_deviceInfo.csv"),
+    ]
+    assert [t for _, _, t in captured] == ["query"]
+
+
 def test_map_outpost_credentials_strips_scheme(monkeypatch):
     """Outpost targets should not include protocol."""
 


### PR DESCRIPTION
## Summary
- map `devices` report to `deviceInfo` query in `REPORT_QUERY_MAP`
- add test ensuring `run_queries` writes `qry_deviceInfo.csv`

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adae1146bc832687ad43edba1f604c