### PR TITLE
Split deviceInfo query into base/access/network variants

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1393,8 +1393,8 @@ REPORT_QUERY_MAP = {
     ],
     # The device_ids report uses a dedicated query
     "device_ids": ["device_ids"],
-    # The devices report uses the deviceInfo query
-    "devices": ["deviceInfo"],
+    # The devices report uses deviceInfo_* queries
+    "devices": ["deviceInfo_base", "deviceInfo_access", "deviceInfo_network"],
 }
 
 def run_queries(search, args, dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -459,11 +459,18 @@ def test_run_queries_executes_devices_report(monkeypatch, tmp_path):
 
     api_mod.run_queries(search, args, outdir)
 
-    assert [q for q, _, _ in captured] == [api_mod.queries.deviceInfo]
-    assert [p for _, p, _ in captured] == [
-        os.path.join(outdir, "qry_deviceInfo.csv"),
+    expected_queries = [
+        api_mod.queries.deviceInfo_base,
+        api_mod.queries.deviceInfo_access,
+        api_mod.queries.deviceInfo_network,
     ]
-    assert [t for _, _, t in captured] == ["query"]
+    assert [q for q, _, _ in captured] == expected_queries
+    assert [p for _, p, _ in captured] == [
+        os.path.join(outdir, "qry_deviceInfo_base.csv"),
+        os.path.join(outdir, "qry_deviceInfo_access.csv"),
+        os.path.join(outdir, "qry_deviceInfo_network.csv"),
+    ]
+    assert [t for _, _, t in captured] == ["query"] * 3
 
 
 def test_map_outpost_credentials_strips_scheme(monkeypatch):


### PR DESCRIPTION
## Summary
- split `devices` report mapping into `deviceInfo_base`, `deviceInfo_access`, and `deviceInfo_network`
- adjust tests to expect three deviceInfo query outputs

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb0ef07ac832681ccdc0b4025ed84