### PR TITLE
Test coverage for devices lookup

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1393,8 +1393,12 @@ REPORT_QUERY_MAP = {
     ],
     # The device_ids report uses a dedicated query
     "device_ids": ["device_ids"],
-    # The devices report uses the deviceInfo query
-    "devices": ["deviceInfo"],
+    # The devices report uses granular deviceInfo queries
+    "devices": [
+        "deviceInfo_base",
+        "deviceInfo_access",
+        "deviceInfo_network",
+    ],
 }
 
 def run_queries(search, args, dir):

--- a/devices_test.py
+++ b/devices_test.py
@@ -18,10 +18,9 @@ from core.access import api_target  # core.access.api_target
 from core.api import (
     init_endpoints,  # core.api.init_endpoints
     get_json,  # core.api.get_json
-    search_results,  # core.api.search_results
+    devices_lookup,  # core.api.devices_lookup
 )
 from core.builder import unique_identities  # core.builder.unique_identities
-from core import queries  # core.queries.deviceInfo
 from core.reporting import devices  # core.reporting.devices
 
 
@@ -116,10 +115,9 @@ def main() -> None:
                 search, args.include_endpoints, args.endpoint_prefix
             )
             logging.debug("Collected %s unique identities", len(identities))
-            results = search_results(search, queries.deviceInfo)  # core.api.search_results
+            lookup = devices_lookup(search, include_network=True)
             logging.debug(
-                "Retrieved %s device search results",
-                len(results) if hasattr(results, "__len__") else "unknown",
+                "Retrieved %s device lookup entries", len(lookup)
             )
 
             devices(search, creds, args, identities=identities)  # core.reporting.devices

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -459,11 +459,18 @@ def test_run_queries_executes_devices_report(monkeypatch, tmp_path):
 
     api_mod.run_queries(search, args, outdir)
 
-    assert [q for q, _, _ in captured] == [api_mod.queries.deviceInfo]
-    assert [p for _, p, _ in captured] == [
-        os.path.join(outdir, "qry_deviceInfo.csv"),
+    expected_queries = [
+        api_mod.queries.deviceInfo_base,
+        api_mod.queries.deviceInfo_access,
+        api_mod.queries.deviceInfo_network,
     ]
-    assert [t for _, _, t in captured] == ["query"]
+    assert [q for q, _, _ in captured] == expected_queries
+    assert [p for _, p, _ in captured] == [
+        os.path.join(outdir, "qry_deviceInfo_base.csv"),
+        os.path.join(outdir, "qry_deviceInfo_access.csv"),
+        os.path.join(outdir, "qry_deviceInfo_network.csv"),
+    ]
+    assert [t for _, _, t in captured] == ["query"] * 3
 
 
 def test_map_outpost_credentials_strips_scheme(monkeypatch):


### PR DESCRIPTION
## Summary
- verify `run_queries` executes all granular device queries
- use `devices_lookup` for manual devices report debugging
- map "devices" to `deviceInfo` query set in `REPORT_QUERY_MAP`

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb0f0c8b88326a07d9171b60c2f6d