### PR TITLE
Split device report into granular queries

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -123,6 +123,8 @@ deviceInfo_network = {
                                 ORDER BY hostname
                                 show
                                 hostname as 'DeviceInfo.hostname',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.endpoint as 'DiscoveryAccess.endpoint',
+                                #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#DiscoveryAccess:Endpoint:Endpoint:Endpoint.endpoint as 'Endpoint.endpoint',
                                 #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.__all_ip_addrs as 'InferredElement.__all_ip_addrs',
                                 #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.ip_addr as 'NetworkInterface.ip_addr',
                                 #DiscoveryResult:DiscoveryAccessResult:DiscoveryAccess:DiscoveryAccess.#::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.fqdns as 'NetworkInterface.fqdns',


### PR DESCRIPTION
## Summary
- Refactor device report to gather base, access, and network details via individual queries and merge them by endpoint
- Extend `deviceInfo_network` query with endpoint data to match monolithic output
- Adjust unit tests for multi-query workflow

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adcd90ead8832683f0fd9c2c62b6d2