### PR TITLE
Ensure devices report pulls complete device metadata

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -592,9 +592,13 @@ def devices(twsearch, twcreds, args, identities=None):
         )
 
     # Gather device information using granular queries and merge by endpoint.
-    base_results = api.search_results(twsearch, queries.deviceInfo_base)
-    access_results = api.search_results(twsearch, queries.deviceInfo_access)
-    network_results = api.search_results(twsearch, queries.deviceInfo_network)
+    # ``search_results`` defaults to returning at most 500 rows which can leave
+    # many devices missing their base metadata (kind, last credential, access
+    # method) when more are present.  Request all available rows for each query
+    # to ensure subsequent merging has the necessary data for every device.
+    base_results = api.search_results(twsearch, queries.deviceInfo_base, limit=0)
+    access_results = api.search_results(twsearch, queries.deviceInfo_access, limit=0)
+    network_results = api.search_results(twsearch, queries.deviceInfo_network, limit=0)
 
     merged = {}
     for result in base_results:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -296,16 +296,20 @@ def test_devices_report_contains_data(monkeypatch):
         }
     ]
     calls = {"base": 0, "access": 0, "network": 0}
+    limits = {}
 
-    def fake_search_results(search, query, *a, **k):
+    def fake_search_results(search, query, limit=500, *a, **k):
         if query == reporting.queries.deviceInfo_base:
             calls["base"] += 1
+            limits["base"] = limit
             return base_result
         if query == reporting.queries.deviceInfo_access:
             calls["access"] += 1
+            limits["access"] = limit
             return access_result
         if query == reporting.queries.deviceInfo_network:
             calls["network"] += 1
+            limits["network"] = limit
             return network_result
         return []
 
@@ -337,6 +341,7 @@ def test_devices_report_contains_data(monkeypatch):
     assert captured["name"] == "devices"
     assert captured["data"]
     assert calls == {"base": 1, "access": 1, "network": 1}
+    assert limits == {"base": 0, "access": 0, "network": 0}
 
 
 def test_devices_report_populates_last_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- fetch all deviceInfo query rows to retain kind, credential, and access method metadata
- test devices report ensures limit=0 and last_* fields populated

## Testing
- `python3 -m pytest tests/test_reporting.py::test_devices_report_contains_data tests/test_reporting.py::test_devices_report_populates_last_fields -q`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adbed4656483269ee67f07c2625a25