### PR TITLE
Refactor discovery queries for incremental detail retrieval

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -276,6 +276,19 @@ last_disco = {
                     process with unique()
 """
 }
+
+last_disco_basic = {
+            "query": """
+                    search DiscoveryAccess where endtime
+                    ORDER BY discovery_endtime DESC
+                    show
+                    #id as 'DiscoveryAccess.id',
+                    endpoint as 'DiscoveryAccess.endpoint',
+                    #DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo.hostname as 'DeviceInfo.hostname',
+                    discovery_endtime as 'DiscoveryAccess.discovery_endtime'
+                    process with unique()
+            """
+}
 ip_schedules = """search DiscoveryAccess
                     show endpoint,
                     nodecount(traverse Member:List:List:DiscoveryRun where scan_type = 'Scheduled') as 'schedules'

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1159,7 +1159,33 @@ def _gather_discovery_data(twsearch, twcreds, args):
         args.endpoint_prefix,
         getattr(args, "max_identities", None),
     )
-    discos = api.search_results(twsearch, queries.last_disco)
+    def _detail_query(disco_id):
+        """Build a detailed last_disco query for a single DiscoveryAccess."""
+        base = queries.last_disco["query"]
+        query = base.replace(
+            "search DiscoveryAccess where endtime",
+            f"search DiscoveryAccess where #id = {disco_id}",
+        )
+        return {"query": query}
+
+    basic_discos = api.search_results(twsearch, queries.last_disco_basic)
+    discos = []
+    seen_ids = set()
+    for entry in basic_discos:
+        if not isinstance(entry, dict):
+            logger.warning("Unexpected discovery access entry: %r", entry)
+            continue
+        disco_id = tools.getr(entry, "DiscoveryAccess.id")
+        if not disco_id or disco_id in seen_ids:
+            continue
+        seen_ids.add(disco_id)
+        detail = api.search_results(
+            twsearch,
+            _detail_query(disco_id),
+            limit=1,
+            cache_name=f"last_disco_{disco_id}",
+        )
+        discos.extend(detail)
     # Reuse cached dropped endpoint results if previously fetched
     dropped = api.search_results(twsearch, queries.dropped_endpoints)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1212,7 +1212,9 @@ def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
     monkeypatch.setattr(reporting.builder, "unique_identities", lambda s, *a, **k: [])
 
     def fake_search_results(search, query, limit=500, *args, **kwargs):
-        if query is reporting.queries.last_disco:
+        if query is reporting.queries.last_disco_basic:
+            return [{"DiscoveryAccess.id": 1, "Endpoint": "1.1.1.1"}]
+        if isinstance(query, dict) and "#id = 1" in query.get("query", ""):
             return [
                 {
                     "Endpoint": "1.1.1.1",
@@ -1286,7 +1288,13 @@ def test_discovery_analysis_merges_latest_fields(monkeypatch):
     monkeypatch.setattr(reporting.builder, "unique_identities", lambda s, *a, **k: [])
 
     def fake_search_results(search, query, limit=500, *args, **kwargs):
-        if query is reporting.queries.last_disco:
+        if query is reporting.queries.last_disco_basic:
+            return [
+                {"DiscoveryAccess.id": 1, "Endpoint": "1.1.1.1"},
+                {"DiscoveryAccess.id": 2, "Endpoint": "1.1.1.1"},
+                {"DiscoveryAccess.id": 3, "Endpoint": "3.3.3.3"},
+            ]
+        if isinstance(query, dict) and "#id = 1" in query.get("query", ""):
             return [
                 {
                     "Endpoint": "1.1.1.1",
@@ -1294,21 +1302,27 @@ def test_discovery_analysis_merges_latest_fields(monkeypatch):
                     "Scan_Endtime": "2024-01-01 00:00:00",
                     "Scan_Endtime_Raw": "2024-01-01T00:00:00+00:00",
                     "End_State": "OK",
-                },
+                }
+            ]
+        if isinstance(query, dict) and "#id = 2" in query.get("query", ""):
+            return [
                 {
                     "Endpoint": "1.1.1.1",
                     "Scan_Endtime": "2024-01-02 00:00:00",
                     "Scan_Endtime_Raw": "2024-01-02T00:00:00+00:00",
                     "End_State": "Failed",
                     "Host_Node_Updated": "2024-01-02 00:00:00",
-                },
+                }
+            ]
+        if isinstance(query, dict) and "#id = 3" in query.get("query", ""):
+            return [
                 {
                     "Endpoint": "3.3.3.3",
                     "Scan_Endtime": "2024-01-03 00:00:00",
                     "Scan_Endtime_Raw": "2024-01-03T00:00:00+00:00",
                     "End_State": "OK",
                     "DeviceInfo.last_credential": "cred1",
-                },
+                }
             ]
         if query is reporting.queries.dropped_endpoints:
             return []


### PR DESCRIPTION
## Summary
- add `last_disco_basic` query for minimal discovery access info
- fetch basic discovery data first and request detailed info per `DiscoveryAccess.id`
- cache each per-id follow-up query to avoid redundant requests

## Testing
- `python3 -m pytest`

> Note: work completed on `work` branch rather than `codex`.


------
https://chatgpt.com/codex/tasks/task_e_68ae28e9cfc083268c73b594260d6681