### PR TITLE
Add asynchronous export search option

### DIFF
--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1159,7 +1159,10 @@ def _gather_discovery_data(twsearch, twcreds, args):
         args.endpoint_prefix,
         getattr(args, "max_identities", None),
     )
-    discos = api.search_results(twsearch, queries.last_disco)
+    if getattr(args, "use_export", False):
+        discos = api.export_search(twsearch, queries.last_disco)
+    else:
+        discos = api.search_results(twsearch, queries.last_disco)
     # Reuse cached dropped endpoint results if previously fetched
     dropped = api.search_results(twsearch, queries.dropped_endpoints)
 

--- a/dismal.py
+++ b/dismal.py
@@ -83,6 +83,13 @@ cache_opts.add_argument(
     required=False,
     help='Force fresh API calls without reading or writing cache.\n\n',
 )
+cache_opts.add_argument(
+    '--use-export',
+    dest='use_export',
+    action='store_true',
+    required=False,
+    help='Use asynchronous export API for heavy queries.\n\n',
+)
 
 # Hidden Options
 parser.add_argument('-k', '--keep-awake',   dest='wakey', action='store_true', required=False, help=argparse.SUPPRESS)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1267,6 +1267,26 @@ def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
     assert dropped_row[idx] == "2024-01-02T00:00:00+00:00"
 
 
+def test_gather_discovery_data_uses_export(monkeypatch):
+    calls = {"export": 0, "search": 0}
+
+    def fake_export_search(api_endpoint, query):
+        calls["export"] += 1
+        return []
+
+    def fake_search_results(api_endpoint, query, *a, **k):
+        calls["search"] += 1
+        return []
+
+    monkeypatch.setattr(reporting.api, "export_search", fake_export_search)
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+    monkeypatch.setattr(reporting.builder, "unique_identities", lambda *a, **k: [])
+    args = types.SimpleNamespace(use_export=True, include_endpoints=None, endpoint_prefix=None)
+    reporting._gather_discovery_data(DummySearch(), DummyCreds(), args)
+    assert calls["export"] == 1
+    assert calls["search"] == 1
+
+
 def test_discovery_analysis_merges_latest_fields(monkeypatch):
     """Fields missing from the chosen record are populated from the latest."""
 


### PR DESCRIPTION
## Summary
- add `export_search` helper for async export jobs
- parse export files as CSV or JSON
- support `--use-export` CLI flag and use export path for `last_disco`

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae28ed9c48832691991839ff113c95