### PR TITLE
Refactor chunked discovery queries with granular keys and warnings

### DIFF
--- a/core/queries.py
+++ b/core/queries.py
@@ -297,6 +297,11 @@ last_disco_basic = {
 # side using :mod:`pandas`.
 
 # 0) Functional Key extraction used for joins
+#
+# ``last_disco_functional_key`` is retained for backwards compatibility but the
+# reporting code now favours the more granular ``last_disco_key_*`` queries
+# defined below.  Each key query maps ``DiscoveryAccess.id`` to a specific
+# related node allowing partial lookups when some queries fail.
 last_disco_functional_key = {
     "query": """
             search DiscoveryAccess where endtime
@@ -308,6 +313,61 @@ last_disco_functional_key = {
             #Member:List:List:DiscoveryRun.#id as "DiscoveryRun.id",
             #::InferredElement:.#id as "InferredElement.id",
             #DiscoveryAccess:Metadata:Detail:SessionResult.#id as "SessionResult.id",
+            explode #::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.#id as "NetworkInterface.id"
+            processwith unique()
+            """,
+}
+
+# 0a) DiscoveryAccess -> DeviceInfo key mapping
+last_disco_key_deviceinfo = {
+    "query": """
+            search DiscoveryAccess where endtime
+            show
+            #id as "DiscoveryAccess.id",
+            #DiscoveryAccess:DiscoveryAccessResult:DiscoveryResult:DeviceInfo.#id as "DeviceInfo.id"
+            processwith unique()
+            """,
+}
+
+# 0b) DiscoveryAccess -> DiscoveryRun key mapping
+last_disco_key_run = {
+    "query": """
+            search DiscoveryAccess where endtime
+            show
+            #id as "DiscoveryAccess.id",
+            #Member:List:List:DiscoveryRun.#id as "DiscoveryRun.id"
+            processwith unique()
+            """,
+}
+
+# 0c) DiscoveryAccess -> InferredElement key mapping
+last_disco_key_inferred = {
+    "query": """
+            search DiscoveryAccess where endtime
+            show
+            #id as "DiscoveryAccess.id",
+            #::InferredElement:.#id as "InferredElement.id"
+            processwith unique()
+            """,
+}
+
+# 0d) DiscoveryAccess -> SessionResult key mapping
+last_disco_key_session = {
+    "query": """
+            search DiscoveryAccess where endtime
+            show
+            #id as "DiscoveryAccess.id",
+            explode #DiscoveryAccess:Metadata:Detail:SessionResult.#id as "SessionResult.id"
+            processwith unique()
+            """,
+}
+
+# 0e) DiscoveryAccess -> NetworkInterface key mapping
+last_disco_key_interface = {
+    "query": """
+            search DiscoveryAccess where endtime
+            show
+            #id as "DiscoveryAccess.id",
             explode #::InferredElement:.#DeviceWithInterface:DeviceInterface:InterfaceOfDevice:NetworkInterface.#id as "NetworkInterface.id"
             processwith unique()
             """,

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1179,30 +1179,116 @@ def chunked_last_disco(twsearch):
         DataFrame containing the merged discovery access information.
     """
 
-    key_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_functional_key))
-    if key_df.empty:
-        return key_df
+    def _fetch_df(query, label, columns):
+        """Return a DataFrame for ``query`` or an empty frame on error."""
 
-    access_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_access))
-    device_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_deviceinfo))
-    run_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_run))
-    session_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_session))
-    inferred_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_inferred))
-    interface_df = pd.DataFrame(api.search_results(twsearch, queries.last_disco_interface))
+        data = api.search_results(twsearch, query)
+        if isinstance(data, list):
+            if data:
+                return pd.DataFrame(data)
+            return pd.DataFrame(columns=columns)
+        print(f"*** WARNING: {label} query failed; continuing with partial data. ***")
+        return pd.DataFrame(columns=columns)
+
+    # Retrieve foreign key mappings individually and merge on DiscoveryAccess.id
+    device_keys = _fetch_df(
+        queries.last_disco_key_deviceinfo,
+        "DeviceInfo key",
+        ["DiscoveryAccess.id", "DeviceInfo.id"],
+    )
+    if device_keys.empty:
+        return device_keys
+    run_keys = _fetch_df(
+        queries.last_disco_key_run,
+        "DiscoveryRun key",
+        ["DiscoveryAccess.id", "DiscoveryRun.id"],
+    )
+    inferred_keys = _fetch_df(
+        queries.last_disco_key_inferred,
+        "InferredElement key",
+        ["DiscoveryAccess.id", "InferredElement.id"],
+    )
+    session_keys = _fetch_df(
+        queries.last_disco_key_session,
+        "SessionResult key",
+        ["DiscoveryAccess.id", "SessionResult.id"],
+    )
+    interface_keys = _fetch_df(
+        queries.last_disco_key_interface,
+        "NetworkInterface key",
+        ["DiscoveryAccess.id", "NetworkInterface.id"],
+    )
+
+    key_df = device_keys.merge(run_keys, how="left", on="DiscoveryAccess.id")
+    key_df = key_df.merge(inferred_keys, how="left", on="DiscoveryAccess.id")
+    key_df = key_df.merge(session_keys, how="left", on="DiscoveryAccess.id")
+    key_df = key_df.merge(interface_keys, how="left", on="DiscoveryAccess.id")
+
+    access_df = _fetch_df(
+        queries.last_disco_access,
+        "DiscoveryAccess",
+        [
+            "DiscoveryAccess.id",
+            "DiscoveryAccess.end_state",
+            "DiscoveryAccess.previous_id",
+            "DiscoveryAccess.next_id",
+        ],
+    )
+    device_df = _fetch_df(
+        queries.last_disco_deviceinfo,
+        "DeviceInfo",
+        [
+            "DeviceInfo.id",
+            "DeviceInfo.last_access_method",
+            "DeviceInfo.last_slave",
+            "DeviceInfo.probed_os",
+        ],
+    )
+    run_df = _fetch_df(
+        queries.last_disco_run,
+        "DiscoveryRun",
+        ["DiscoveryRun.id"],
+    )
+    session_df = _fetch_df(
+        queries.last_disco_session,
+        "SessionResult",
+        [
+            "SessionResult.id",
+            "SessionResult.provider",
+            "SessionResult.session_type",
+            "SessionResult.success",
+        ],
+    )
+    inferred_df = _fetch_df(
+        queries.last_disco_inferred,
+        "InferredElement",
+        ["InferredElement.id", "InferredElement.__all_ip_addrs"],
+    )
+    interface_df = _fetch_df(
+        queries.last_disco_interface,
+        "NetworkInterface",
+        ["NetworkInterface.id", "NetworkInterface.ip_addr"],
+    )
 
     merged = key_df.merge(access_df, how="left", on="DiscoveryAccess.id")
     merged = merged.merge(device_df, how="left", on="DeviceInfo.id")
     merged = merged.merge(run_df, how="left", on="DiscoveryRun.id")
-    merged = merged.merge(session_df, how="left", on="SessionResult.id")
-    merged = merged.merge(inferred_df, how="left", on="InferredElement.id")
-    merged = merged.merge(interface_df, how="left", on="NetworkInterface.id")
+    if "SessionResult.id" in merged.columns:
+        merged = merged.merge(session_df, how="left", on="SessionResult.id")
+    if "InferredElement.id" in merged.columns:
+        merged = merged.merge(inferred_df, how="left", on="InferredElement.id")
+    if "NetworkInterface.id" in merged.columns:
+        merged = merged.merge(interface_df, how="left", on="NetworkInterface.id")
 
     session_logged = merged.groupby("DiscoveryAccess.id")["SessionResult.provider"].transform(
         lambda s: s.isna().any()
     )
     merged["DiscoveryAccess.session_results_logged"] = session_logged
 
-    prev_map = access_df.set_index("DiscoveryAccess.id")["DiscoveryAccess.end_state"]
+    if "DiscoveryAccess.end_state" in access_df.columns:
+        prev_map = access_df.set_index("DiscoveryAccess.id")["DiscoveryAccess.end_state"]
+    else:
+        prev_map = pd.Series(dtype=object)
     merged["DiscoveryAccess.previous_end_state"] = merged["DiscoveryAccess.previous_id"].map(prev_map)
 
     merged["DiscoveryAccess.access_method"] = merged[

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1216,7 +1216,11 @@ def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
         return []
 
     def fake_chunked_last_disco(search):
-        reporting.api.search_results(search, reporting.queries.last_disco_functional_key)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_deviceinfo)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_run)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_inferred)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_session)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_interface)
         reporting.api.search_results(search, reporting.queries.last_disco_access)
         reporting.api.search_results(search, reporting.queries.last_disco_deviceinfo)
         reporting.api.search_results(search, reporting.queries.last_disco_run)
@@ -1293,7 +1297,11 @@ def test_discovery_analysis_includes_raw_timestamp(monkeypatch):
     assert dropped_row[idx] == "2024-01-02T00:00:00+00:00"
 
     for q in [
-        reporting.queries.last_disco_functional_key,
+        reporting.queries.last_disco_key_deviceinfo,
+        reporting.queries.last_disco_key_run,
+        reporting.queries.last_disco_key_inferred,
+        reporting.queries.last_disco_key_session,
+        reporting.queries.last_disco_key_interface,
         reporting.queries.last_disco_access,
         reporting.queries.last_disco_deviceinfo,
         reporting.queries.last_disco_run,
@@ -1311,7 +1319,11 @@ def test_gather_discovery_data_calls_chunked_queries(monkeypatch):
         return []
 
     def fake_chunked_last_disco(search):
-        reporting.api.search_results(search, reporting.queries.last_disco_functional_key)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_deviceinfo)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_run)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_inferred)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_session)
+        reporting.api.search_results(search, reporting.queries.last_disco_key_interface)
         reporting.api.search_results(search, reporting.queries.last_disco_access)
         reporting.api.search_results(search, reporting.queries.last_disco_deviceinfo)
         reporting.api.search_results(search, reporting.queries.last_disco_run)
@@ -1334,7 +1346,11 @@ def test_gather_discovery_data_calls_chunked_queries(monkeypatch):
     reporting._gather_discovery_data(DummySearch(), DummyCreds(), args)
 
     for q in [
-        reporting.queries.last_disco_functional_key,
+        reporting.queries.last_disco_key_deviceinfo,
+        reporting.queries.last_disco_key_run,
+        reporting.queries.last_disco_key_inferred,
+        reporting.queries.last_disco_key_session,
+        reporting.queries.last_disco_key_interface,
         reporting.queries.last_disco_access,
         reporting.queries.last_disco_deviceinfo,
         reporting.queries.last_disco_run,
@@ -1357,7 +1373,11 @@ def test_discovery_analysis_merges_latest_fields(monkeypatch):
 
     def fake_chunked_last_disco(search):
         for q in [
-            reporting.queries.last_disco_functional_key,
+            reporting.queries.last_disco_key_deviceinfo,
+            reporting.queries.last_disco_key_run,
+            reporting.queries.last_disco_key_inferred,
+            reporting.queries.last_disco_key_session,
+            reporting.queries.last_disco_key_interface,
             reporting.queries.last_disco_access,
             reporting.queries.last_disco_deviceinfo,
             reporting.queries.last_disco_run,
@@ -1424,7 +1444,11 @@ def test_discovery_analysis_merges_latest_fields(monkeypatch):
     assert second[headers.index("credential_name")] == "CRED"
 
     for q in [
-        reporting.queries.last_disco_functional_key,
+        reporting.queries.last_disco_key_deviceinfo,
+        reporting.queries.last_disco_key_run,
+        reporting.queries.last_disco_key_inferred,
+        reporting.queries.last_disco_key_session,
+        reporting.queries.last_disco_key_interface,
         reporting.queries.last_disco_access,
         reporting.queries.last_disco_deviceinfo,
         reporting.queries.last_disco_run,

--- a/tests/test_z_last_disco_chunks.py
+++ b/tests/test_z_last_disco_chunks.py
@@ -20,21 +20,25 @@ class DummySearch:
 def test_chunked_last_disco_merges(monkeypatch):
     """The chunked query pieces are joined into a single DataFrame."""
 
-    key_data = [
+    device_keys = [{"DiscoveryAccess.id": 1, "DeviceInfo.id": 10}]
+    run_keys = [{"DiscoveryAccess.id": 1, "DiscoveryRun.id": 20}]
+    inferred_keys = [{"DiscoveryAccess.id": 1, "InferredElement.id": 30}]
+    session_keys = [{"DiscoveryAccess.id": 1, "SessionResult.id": 40}]
+    interface_keys = [{"DiscoveryAccess.id": 1, "NetworkInterface.id": 50}]
+
+    access_data = [
         {
             "DiscoveryAccess.id": 1,
+            "DiscoveryAccess.end_state": "OK",
             "DiscoveryAccess.previous_id": 2,
             "DiscoveryAccess.next_id": None,
-            "DeviceInfo.id": 10,
-            "DiscoveryRun.id": 20,
-            "InferredElement.id": 30,
-            "SessionResult.id": 40,
-            "NetworkInterface.id": 50,
-        }
-    ]
-    access_data = [
-        {"DiscoveryAccess.id": 1, "DiscoveryAccess.end_state": "OK"},
-        {"DiscoveryAccess.id": 2, "DiscoveryAccess.end_state": "Fail"},
+        },
+        {
+            "DiscoveryAccess.id": 2,
+            "DiscoveryAccess.end_state": "Fail",
+            "DiscoveryAccess.previous_id": None,
+            "DiscoveryAccess.next_id": 1,
+        },
     ]
     device_data = [
         {
@@ -65,8 +69,16 @@ def test_chunked_last_disco_merges(monkeypatch):
     ]
 
     def fake_search_results(_search, query, *args, **kwargs):
-        if query is queries.last_disco_functional_key:
-            return key_data
+        if query is queries.last_disco_key_deviceinfo:
+            return device_keys
+        if query is queries.last_disco_key_run:
+            return run_keys
+        if query is queries.last_disco_key_inferred:
+            return inferred_keys
+        if query is queries.last_disco_key_session:
+            return session_keys
+        if query is queries.last_disco_key_interface:
+            return interface_keys
         if query is queries.last_disco_access:
             return access_data
         if query is queries.last_disco_deviceinfo:
@@ -89,3 +101,159 @@ def test_chunked_last_disco_merges(monkeypatch):
     assert df.loc[0, "DiscoveryAccess.access_method"] == "ssh"
     assert df.loc[0, "DiscoveryAccess.current_access"] == "ssh"
     assert bool(df.loc[0, "DiscoveryAccess.session_results_logged"]) is True
+
+
+def test_chunked_last_disco_matches_wide(monkeypatch):
+    """Chunked output matches the original wide query for small fixtures."""
+
+    device_keys = [{"DiscoveryAccess.id": 1, "DeviceInfo.id": 10}]
+    run_keys = [{"DiscoveryAccess.id": 1, "DiscoveryRun.id": 20}]
+    inferred_keys = [{"DiscoveryAccess.id": 1, "InferredElement.id": 30}]
+    session_keys = [{"DiscoveryAccess.id": 1, "SessionResult.id": 40}]
+    interface_keys = [{"DiscoveryAccess.id": 1, "NetworkInterface.id": 50}]
+
+    access_data = [
+        {
+            "DiscoveryAccess.id": 1,
+            "DiscoveryAccess.end_state": "OK",
+            "DiscoveryAccess.previous_id": 2,
+            "DiscoveryAccess.next_id": None,
+        },
+        {
+            "DiscoveryAccess.id": 2,
+            "DiscoveryAccess.end_state": "Fail",
+            "DiscoveryAccess.previous_id": None,
+            "DiscoveryAccess.next_id": 1,
+        },
+    ]
+    device_data = [
+        {
+            "DeviceInfo.id": 10,
+            "DeviceInfo.hostname": "h",
+            "DeviceInfo.last_access_method": "ssh",
+            "DeviceInfo.last_slave": None,
+            "DeviceInfo.probed_os": None,
+        }
+    ]
+    run_data = [{"DiscoveryRun.id": 20, "DiscoveryRun.label": "r"}]
+    session_data = [
+        {
+            "SessionResult.id": 40,
+            "SessionResult.success": True,
+            "SessionResult.session_type": "telnet",
+            "SessionResult.provider": None,
+        }
+    ]
+    inferred_data = [
+        {
+            "InferredElement.id": 30,
+            "InferredElement.__all_ip_addrs": "1.1.1.1",
+        }
+    ]
+    interface_data = [
+        {"NetworkInterface.id": 50, "NetworkInterface.ip_addr": "1.1.1.1"}
+    ]
+
+    wide_data = [
+        {
+            "DiscoveryAccess.id": 1,
+            "DiscoveryAccess.previous_id": 2,
+            "DiscoveryAccess.next_id": None,
+            "DeviceInfo.id": 10,
+            "DiscoveryRun.id": 20,
+            "InferredElement.id": 30,
+            "SessionResult.id": 40,
+            "NetworkInterface.id": 50,
+            "DiscoveryAccess.end_state": "OK",
+            "DeviceInfo.hostname": "h",
+            "DeviceInfo.last_access_method": "ssh",
+            "DeviceInfo.last_slave": None,
+            "DeviceInfo.probed_os": None,
+            "DiscoveryRun.label": "r",
+            "SessionResult.success": True,
+            "SessionResult.session_type": "telnet",
+            "SessionResult.provider": None,
+            "InferredElement.__all_ip_addrs": "1.1.1.1",
+            "NetworkInterface.ip_addr": "1.1.1.1",
+            "DiscoveryAccess.previous_end_state": "Fail",
+            "DiscoveryAccess.access_method": "ssh",
+            "DiscoveryAccess.current_access": "ssh",
+            "DiscoveryAccess.session_results_logged": True,
+        }
+    ]
+
+    def fake_search_results(_search, query, *args, **kwargs):
+        if query is queries.last_disco:
+            return wide_data
+        if query is queries.last_disco_key_deviceinfo:
+            return device_keys
+        if query is queries.last_disco_key_run:
+            return run_keys
+        if query is queries.last_disco_key_inferred:
+            return inferred_keys
+        if query is queries.last_disco_key_session:
+            return session_keys
+        if query is queries.last_disco_key_interface:
+            return interface_keys
+        if query is queries.last_disco_access:
+            return access_data
+        if query is queries.last_disco_deviceinfo:
+            return device_data
+        if query is queries.last_disco_run:
+            return run_data
+        if query is queries.last_disco_session:
+            return session_data
+        if query is queries.last_disco_inferred:
+            return inferred_data
+        if query is queries.last_disco_interface:
+            return interface_data
+        return []
+
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+
+    chunked = reporting.chunked_last_disco(DummySearch())
+    wide = pd.DataFrame(wide_data)
+
+    pd.testing.assert_frame_equal(
+        chunked.sort_index(axis=1), wide.sort_index(axis=1), check_dtype=False
+    )
+
+
+def test_chunked_last_disco_warns_on_partial_timeout(monkeypatch, capsys):
+    """Failures in a sub-query trigger a warning but return partial data."""
+
+    device_keys = [{"DiscoveryAccess.id": 1, "DeviceInfo.id": 10}]
+
+    access_data = [
+        {
+            "DiscoveryAccess.id": 1,
+            "DiscoveryAccess.end_state": "OK",
+            "DiscoveryAccess.previous_id": None,
+            "DiscoveryAccess.next_id": None,
+        }
+    ]
+    device_data = [
+        {
+            "DeviceInfo.id": 10,
+            "DeviceInfo.last_access_method": "ssh",
+            "DeviceInfo.last_slave": None,
+            "DeviceInfo.probed_os": None,
+        }
+    ]
+
+    def fake_search_results(_search, query, *args, **kwargs):
+        if query is queries.last_disco_key_deviceinfo:
+            return device_keys
+        if query is queries.last_disco_key_run:
+            return {"error": "timeout"}
+        if query is queries.last_disco_access:
+            return access_data
+        if query is queries.last_disco_deviceinfo:
+            return device_data
+        return []
+
+    monkeypatch.setattr(reporting.api, "search_results", fake_search_results)
+
+    reporting.chunked_last_disco(DummySearch())
+    captured = capsys.readouterr()
+    assert "partial data" in captured.out


### PR DESCRIPTION
## Summary
- split `last_disco` key lookup into individual mapping queries for device, run, inferred element, session, and interface IDs
- refactor `chunked_last_disco` to merge new key queries and warn when sub-queries fail
- add regression tests covering wide query parity and partial timeout warnings

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4f7c92c083268ef8bf1004d11844